### PR TITLE
fix for modelCustomTransformToDictionary support

### DIFF
--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -1071,8 +1071,8 @@ static id ModelToJSONObjectRecursive(NSObject *model) {
         }
     }];
     
-    if (modelMeta->_hasCustomTransformFromDictonary) {
-        BOOL suc = [((id<YYModel>)model) modelCustomTransformFromDictionary:dic];
+    if (modelMeta->_hasCustomTransformToDictionary) {
+        BOOL suc = [((id<YYModel>)model) modelCustomTransformToDictionary:dic];
         if (!suc) return nil;
     }
     return result;


### PR DESCRIPTION
`modelCustomTransformToDictionary` method seem to be unused by YYModel. `ModelToJSONObjectRecursive` uses `modelCustomTransformFromDictionary` instead, for some reason.