### PR TITLE
Ability to choose custom model (sub-)class based on dictionary Data

### DIFF
--- a/YYModel/NSObject+YYModel.h
+++ b/YYModel/NSObject+YYModel.h
@@ -320,7 +320,36 @@
 + (NSDictionary *)modelContainerPropertyGenericClass;
 
 /**
- TODO: description and example
+ If you need to create instances of different classes during json->object transform,
+ use the method to choose custom class based on dictionary data.
+ 
+ @discussion If the model implements this method, it will be called to determine resulting class
+ during `+modelWithJSON:`, `+modelWithDictionary:`, conveting object of properties of parent objects 
+ (both singular and containers via `+modelContainerPropertyGenericClass`).
+ 
+ Example:
+        @class YYCircle, YYRectangle, YYLine;
+ 
+        @implementation YYShape
+
+        + (Class)modelCustomClassForDictionary:(NSDictionary*)dictionary {
+            if (dictionary[@"radius"] != nil) {
+                return [YYCircle class];
+            } else if (dictionary[@"width"] != nil) {
+                return [YYRectangle class];
+            } else if (dictionary[@"y2"] != nil) {
+                return [YYLine class];
+            } else {
+                return [self class];
+            }
+        }
+
+        @end
+
+ @param dictionary The json/kv dictionary.
+ 
+ @return Class to create from this dictionary
+
  */
 + (Class)modelCustomClassForDictionary:(NSDictionary*)dictionary;
 

--- a/YYModel/NSObject+YYModel.h
+++ b/YYModel/NSObject+YYModel.h
@@ -348,7 +348,7 @@
 
  @param dictionary The json/kv dictionary.
  
- @return Class to create from this dictionary
+ @return Class to create from this dictionary, `nil` to use current class.
 
  */
 + (Class)modelCustomClassForDictionary:(NSDictionary*)dictionary;

--- a/YYModel/NSObject+YYModel.h
+++ b/YYModel/NSObject+YYModel.h
@@ -320,6 +320,11 @@
 + (NSDictionary *)modelContainerPropertyGenericClass;
 
 /**
+ TODO: description and example
+ */
++ (Class)modelCustomClassForDictionary:(NSDictionary*)dictionary;
+
+/**
  All the properties in blacklist will be ignored in model transform process.
  Returns nil to ignore this feature.
  

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -314,7 +314,7 @@ static force_inline id YYValueForKeyPath(__unsafe_unretained NSDictionary *dic, 
 
     if (generic) {
         meta->_hasCustomClassFromDictionary = [generic respondsToSelector:@selector(modelCustomClassForDictionary:)];
-    } else {
+    } else if (meta->_cls && meta->_type == YYEncodingTypeNSUnknown) {
         meta->_hasCustomClassFromDictionary = [meta->_cls respondsToSelector:@selector(modelCustomClassForDictionary:)];
     }
 

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -733,8 +733,8 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                                 if ([one isKindOfClass:meta->_genericCls]) {
                                     [objectArr addObject:one];
                                 } else if ([one isKindOfClass:[NSDictionary class]]) {
-                                    _YYModelMeta *modelMeta = [_YYModelMeta metaWithClass:meta->_genericCls];
                                     Class clazz = meta->_genericCls;
+                                    _YYModelMeta *modelMeta = [_YYModelMeta metaWithClass:clazz];
                                     if (modelMeta->_hasCustomClassFromDictionary) {
                                         clazz = [clazz modelCustomClassForDictionary:one] ?: clazz;
                                     }
@@ -778,8 +778,8 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                             NSMutableDictionary *dic = [NSMutableDictionary new];
                             [((NSDictionary *)value) enumerateKeysAndObjectsUsingBlock:^(NSString *oneKey, NSObject *oneValue, BOOL *stop) {
                                 if ([oneValue isKindOfClass:[NSDictionary class]]) {
-                                    _YYModelMeta *modelMeta = [_YYModelMeta metaWithClass:meta->_genericCls];
                                     Class clazz = meta->_genericCls;
+                                    _YYModelMeta *modelMeta = [_YYModelMeta metaWithClass:clazz];
                                     if (modelMeta->_hasCustomClassFromDictionary) {
                                         clazz = [clazz modelCustomClassForDictionary:oneValue] ?: clazz;
                                     }
@@ -816,8 +816,8 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                             if ([one isKindOfClass:meta->_genericCls]) {
                                 [set addObject:one];
                             } else if ([one isKindOfClass:[NSDictionary class]]) {
-                                _YYModelMeta *modelMeta = [_YYModelMeta metaWithClass:meta->_genericCls];
                                 Class clazz = meta->_genericCls;
+                                _YYModelMeta *modelMeta = [_YYModelMeta metaWithClass:clazz];
                                 if (modelMeta->_hasCustomClassFromDictionary) {
                                     clazz = [clazz modelCustomClassForDictionary:one] ?: clazz;
                                 }
@@ -859,8 +859,8 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                     if (one) {
                         [one yy_modelSetWithDictionary:value];
                     } else {
-                        _YYModelMeta *modelMeta = [_YYModelMeta metaWithClass:meta->_cls];
                         Class clazz = meta->_cls;
+                        _YYModelMeta *modelMeta = [_YYModelMeta metaWithClass:clazz];
                         if (modelMeta->_hasCustomClassFromDictionary) {
                             clazz = [clazz modelCustomClassForDictionary:value] ?: clazz;
                         }
@@ -1116,8 +1116,8 @@ static id ModelToJSONObjectRecursive(NSObject *model) {
 + (instancetype)yy_modelWithDictionary:(NSDictionary *)dictionary {
     if (!dictionary || dictionary == (id)kCFNull) return nil;
     if (![dictionary isKindOfClass:[NSDictionary class]]) return nil;
-    _YYModelMeta *modelMeta = [_YYModelMeta metaWithClass:[self class]];
     Class clazz = [self class];
+    _YYModelMeta *modelMeta = [_YYModelMeta metaWithClass:clazz];
     if (modelMeta->_hasCustomClassFromDictionary) {
         clazz = [clazz modelCustomClassForDictionary:dictionary] ?: clazz;
     }


### PR DESCRIPTION
Hi.

I've added a `+modelCustomClassForDictionary:` method to YYModel to be able to choose model class dynamically based on dictionary data. It's inspired by Mantle's `+classForParsingJSONDictionary:` and seem to work in my project for direct conversions, containers and nested objects. 

What do you think about it?
