### PR TITLE
missing break in case YYEncodingTypeInt64\ losing accuracy of NSDecim…

### DIFF
--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -572,7 +572,8 @@ static force_inline void ModelSetNumberToProperty(__unsafe_unretained id model,
             ((void (*)(id, SEL, uint32_t))(void *) objc_msgSend)((id)model, meta->_setter, (uint32_t)num.unsignedIntValue);
         } break;
         case YYEncodingTypeInt64: {
-            ((void (*)(id, SEL, int64_t))(void *) objc_msgSend)((id)model, meta->_setter, (int64_t)num.longLongValue);
+            ((void (*)(id, SEL, int64_t))(void *) objc_msgSend)((id)model, meta->_setter, (int64_t)num.stringValue.longLongValue);
+            break;
         }
         case YYEncodingTypeUInt64: {
             ((void (*)(id, SEL, uint64_t))(void *) objc_msgSend)((id)model, meta->_setter, (uint64_t)num.unsignedLongLongValue);


### PR DESCRIPTION
1. 在case 完int64后没有break
2. 发现在ios7的机型下满长的int64会在json转的时候转成NSDecimalNumber 然后向下转int后出现精度丢失>=8 并没发现问题，我现在处理方式就全都向string转一次再转回来了