### PR TITLE
添加 动态改变 mapper中key值的方法。

### DIFF
--- a/YYModel/NSObject+YYModel.h
+++ b/YYModel/NSObject+YYModel.h
@@ -400,3 +400,42 @@
 - (BOOL)modelCustomTransformToDictionary:(NSMutableDictionary *)dic;
 
 @end
+
+
+
+
+/*
+ *  sometimes server will give sevrial key about one value in diffrent protocol, like
+ *  {@"name":@"apple, @"key":@"1"},
+ *  {@"name1":@"apple, @"key":@"1"}
+ *  {@"name2":@"apple, @"key":@"1"}
+ *  the struct is same, but key is diffrent. Creating a subclass is so complicated, so you can just dynamic subclass and change the mapper.
+ */
+
+/**
+ *  dynamic create a subclass for changing mapper
+ *  @param originClass the origin class that container the origin struct
+ *  @param kindKey     just for diffrent biz
+ *  @param mapper      the new mapper
+ *
+ *  @return a subclass that can decode with the new mapper
+ */
+
+FOUNDATION_EXTERN Class YYRegisterCustomPropertyMapper(Class originClass,
+                                                       NSString* kindKey,
+                                                       NSDictionary* mapper);
+
+/**
+ *  dynamic create a subclass for changing GenericClass
+ *
+ *  @param originClass the origin class that container the origin struct
+ *  @param kindKey     just for diffrent biz
+ *  @param customContainer  the new genericClass mapper
+ *
+ *  @return a subclass that can decode with the new mapper
+ */
+FOUNDATION_EXTERN Class YYRegisterCustomContainerPropertyGenericClass(Class originClass,
+                                                                      NSString* kindKey,
+                                                                      NSDictionary* customContainer);
+
+

--- a/YYModelTests/YYTestModelMapper.m
+++ b/YYModelTests/YYTestModelMapper.m
@@ -231,4 +231,108 @@
     XCTAssertTrue([[model.mArray firstObject] isKindOfClass:[YYTestPropertyMapperModelAuto class]]);
 }
 
+
+- (void) testRemapKey {
+    
+    NSString *json;
+    NSDictionary *jsonObject = nil;
+    YYTestPropertyMapperModelContainer *model;
+    
+    /**
+     *  name 使用 xxx解析
+     *
+     */
+    static NSString* kYYKindTest = @"test";
+    Class c =  YYRegisterCustomPropertyMapper([YYTestPropertyMapperModelAuto class],
+                                              kYYKindTest,
+                                              @{@"name":@"xxx"});
+    
+    // 重新定义array使用新类解析
+    c = YYRegisterCustomContainerPropertyGenericClass(YYTestPropertyMapperModelContainerGeneric.class,
+                                                      @"xxx",
+                                                      @{@"array":c,
+                                                        @"mArray" :c ,
+                                                        @"dict" :c ,
+                                                        @"mDict" : c ,
+                                                        @"set" : c,
+                                                        @"mSet":c });
+    json = @"{\"array\":[\n  {\"xxx\":\"Apple\", \"count\":10},\n  {\"xxx\":\"Banana\", \"count\":11},\n  {\"xxx\":\"Pear\", \"count\":12},\n  null\n]}";
+    
+    model = [c yy_modelWithJSON:json];
+    XCTAssertTrue([model.array isKindOfClass:[NSArray class]]);
+    XCTAssertTrue(model.array.count == 3);
+    
+    jsonObject = [model yy_modelToJSONObject];
+    XCTAssertTrue([jsonObject[@"array"] isKindOfClass:[NSArray class]]);
+    
+    model = [c yy_modelWithJSON:json];
+    XCTAssertTrue([model.array isKindOfClass:[NSArray class]]);
+    XCTAssertTrue(model.array.count == 3);
+    XCTAssertTrue([((YYTestPropertyMapperModelAuto *)model.array[0]).name isEqualToString:@"Apple"]);
+    XCTAssertTrue([((YYTestPropertyMapperModelAuto *)model.array[0]).count isEqual:@10]);
+    XCTAssertTrue([((YYTestPropertyMapperModelAuto *)model.array[2]).name isEqualToString:@"Pear"]);
+    XCTAssertTrue([((YYTestPropertyMapperModelAuto *)model.array[2]).count isEqual:@12]);
+    XCTAssertTrue([model.mArray isKindOfClass:[NSMutableArray class]]);
+    
+    jsonObject = [model yy_modelToJSONObject];
+    XCTAssertTrue([jsonObject[@"array"] isKindOfClass:[NSArray class]]);
+    
+    json = @"{\"dict\":{\n  \"A\":{\"name\":\"Apple\", \"count\":10},\n  \"B\":{\"name\":\"Banana\", \"count\":11},\n  \"P\":{\"name\":\"Pear\", \"count\":12},\n  \"N\":null\n}}";
+    
+    model = [YYTestPropertyMapperModelContainer yy_modelWithJSON:json];
+    XCTAssertTrue([model.dict isKindOfClass:[NSDictionary class]]);
+    XCTAssertTrue(model.dict.count == 4);
+    
+    jsonObject = [model yy_modelToJSONObject];
+    XCTAssertTrue(jsonObject != nil);
+    
+    model = [YYTestPropertyMapperModelContainerGeneric yy_modelWithJSON:json];
+    XCTAssertTrue([model.dict isKindOfClass:[NSDictionary class]]);
+    XCTAssertTrue(model.dict.count == 3);
+    XCTAssertTrue([((YYTestPropertyMapperModelAuto *)model.dict[@"A"]).name isEqualToString:@"Apple"]);
+    XCTAssertTrue([((YYTestPropertyMapperModelAuto *)model.dict[@"A"]).count isEqual:@10]);
+    XCTAssertTrue([((YYTestPropertyMapperModelAuto *)model.dict[@"P"]).name isEqualToString:@"Pear"]);
+    XCTAssertTrue([((YYTestPropertyMapperModelAuto *)model.dict[@"P"]).count isEqual:@12]);
+    XCTAssertTrue([model.mDict isKindOfClass:[NSMutableDictionary class]]);
+    
+    jsonObject = [model yy_modelToJSONObject];
+    XCTAssertTrue(jsonObject != nil);
+    
+    json = @"{\"set\":[\n  {\"name\":\"Apple\", \"count\":10},\n  {\"name\":\"Banana\", \"count\":11},\n  {\"name\":\"Pear\", \"count\":12},\n  null\n]}";
+    
+    model = [YYTestPropertyMapperModelContainer yy_modelWithJSON:json];
+    XCTAssertTrue([model.set isKindOfClass:[NSSet class]]);
+    XCTAssertTrue(model.set.count == 4);
+    
+    jsonObject = [model yy_modelToJSONObject];
+    XCTAssertTrue(jsonObject != nil);
+    
+    model = [YYTestPropertyMapperModelContainerGeneric yy_modelWithJSON:json];
+    XCTAssertTrue([model.set isKindOfClass:[NSSet class]]);
+    XCTAssertTrue(model.set.count == 3);
+    XCTAssertTrue([((YYTestPropertyMapperModelAuto *)model.set.anyObject).name isKindOfClass:[NSString class]]);
+    XCTAssertTrue([model.mSet isKindOfClass:[NSMutableSet class]]);
+    
+    jsonObject = [model yy_modelToJSONObject];
+    XCTAssertTrue(jsonObject != nil);
+    
+    model = [YYTestPropertyMapperModelContainerGeneric yy_modelWithJSON:@{@"set" : @[[YYTestPropertyMapperModelAuto new]]}];
+    XCTAssertTrue([model.set isKindOfClass:[NSSet class]]);
+    XCTAssertTrue([[model.set anyObject] isKindOfClass:[YYTestPropertyMapperModelAuto class]]);
+    
+    model = [YYTestPropertyMapperModelContainerGeneric yy_modelWithJSON:@{@"array" : [NSSet setWithArray:@[[YYTestPropertyMapperModelAuto new]]]}];
+    XCTAssertTrue([model.array isKindOfClass:[NSArray class]]);
+    XCTAssertTrue([[model.array firstObject] isKindOfClass:[YYTestPropertyMapperModelAuto class]]);
+    
+    model = [YYTestPropertyMapperModelContainer yy_modelWithJSON:@{@"mArray" : @[[YYTestPropertyMapperModelAuto new]]}];
+    XCTAssertTrue([model.mArray isKindOfClass:[NSMutableArray class]]);
+    XCTAssertTrue([[model.mArray firstObject] isKindOfClass:[YYTestPropertyMapperModelAuto class]]);
+    
+    model = [YYTestPropertyMapperModelContainer yy_modelWithJSON:@{@"mArray" : [NSSet setWithArray:@[[YYTestPropertyMapperModelAuto new]]]}];
+    XCTAssertTrue([model.mArray isKindOfClass:[NSMutableArray class]]);
+    XCTAssertTrue([[model.mArray firstObject] isKindOfClass:[YYTestPropertyMapperModelAuto class]]);
+}
+
+
+
 @end


### PR DESCRIPTION
有些情况下，对一个类型，但是服务器返回的数据的key值不一样，但是结构一样。比如：

@interface AClass :  NSObject
@property (nonatomic, strong) NSString* name;
@property (nonatomic, strong) NSString* key;
@end

服务器传回的数据可能是
{@"name":@"apple", @"key":@"1"}
{@"name2":@"apple", @"key":@"1"}
{@"name3":@"apple", @"key":@"1"}
{@"name4":@"apple", @"key":@"1"}

都是这个AClass的结构，但是为了适配不同的情况，为每一种情况都建一个类维护起来有些复杂。尤其是要维护多个model类。这里提供了几个方法，可以动态的修改解析映射表(mapper)。

Class c =  YYRegisterCustomPropertyMapper([YYTestPropertyMapperModelAuto class],
                                             @"aKind",
                                              @{@"name":@"name1"});
model = [c yy_modelWithJSON:json];

省去在编译前手动生成类的麻烦，而又能适配各种情况。