### PR TITLE
Added millisecond support to date parsing

### DIFF
--- a/Framework/Info.plist
+++ b/Framework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/YYModel.podspec
+++ b/YYModel.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YYModel'
   s.summary      = 'High performance model framework for iOS/OSX.'
-  s.version      = '1.0.2'
+  s.version      = '1.0.3'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.authors      = { 'ibireme' => 'ibireme@gmail.com' }
   s.social_media_url = 'http://blog.ibireme.com'

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -134,7 +134,7 @@ static force_inline NSNumber *YYNSNumberCreateFromID(__unsafe_unretained id valu
 /// Parse string to date.
 static force_inline NSDate *YYNSDateFromString(__unsafe_unretained NSString *string) {
     typedef NSDate* (^YYNSDateParseBlock)(NSString *string);
-    #define kParserNum 32
+    #define kParserNum 34
     static YYNSDateParseBlock blocks[kParserNum + 1] = {0};
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -153,6 +153,8 @@ static force_inline NSDate *YYNSDateFromString(__unsafe_unretained NSString *str
             /*
              2014-01-20 12:24:48
              2014-01-20T12:24:48   // Google
+             2014-01-20 12:24:48.000
+             2014-01-20T12:24:48.000
              */
             NSDateFormatter *formatter1 = [[NSDateFormatter alloc] init];
             formatter1.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
@@ -163,12 +165,30 @@ static force_inline NSDate *YYNSDateFromString(__unsafe_unretained NSString *str
             formatter2.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
             formatter2.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
             formatter2.dateFormat = @"yyyy-MM-dd HH:mm:ss";
+
+            NSDateFormatter *formatter3 = [[NSDateFormatter alloc] init];
+            formatter3.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+            formatter3.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
+            formatter3.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSS";
+
+            NSDateFormatter *formatter4 = [[NSDateFormatter alloc] init];
+            formatter4.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+            formatter4.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
+            formatter4.dateFormat = @"yyyy-MM-dd HH:mm:ss.SSS";
             
             blocks[19] = ^(NSString *string) {
                 if ([string characterAtIndex:10] == 'T') {
                     return [formatter1 dateFromString:string];
                 } else {
                     return [formatter2 dateFromString:string];
+                }
+            };
+
+            blocks[23] = ^(NSString *string) {
+                if ([string characterAtIndex:10] == 'T') {
+                    return [formatter3 dateFromString:string];
+                } else {
+                    return [formatter4 dateFromString:string];
                 }
             };
         }
@@ -178,23 +198,40 @@ static force_inline NSDate *YYNSDateFromString(__unsafe_unretained NSString *str
              2014-01-20T12:24:48Z        // Github, Apple
              2014-01-20T12:24:48+0800    // Facebook
              2014-01-20T12:24:48+12:00   // Google
+             2014-01-20T12:24:48.000Z
+             2014-01-20T12:24:48.000+0800
+             2014-01-20T12:24:48.000+12:00
              */
             NSDateFormatter *formatter = [NSDateFormatter new];
             formatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
             formatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ssZ";
+
+            NSDateFormatter *formatter2 = [NSDateFormatter new];
+            formatter2.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+            formatter2.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+
             blocks[20] = ^(NSString *string) { return [formatter dateFromString:string]; };
-            blocks[24] = ^(NSString *string) { return [formatter dateFromString:string]; };
+            blocks[24] = ^(NSString *string) { return [formatter dateFromString:string]?: [formatter2 dateFromString:string]; };
             blocks[25] = ^(NSString *string) { return [formatter dateFromString:string]; };
+            blocks[28] = ^(NSString *string) { return [formatter2 dateFromString:string]; };
+            blocks[29] = ^(NSString *string) { return [formatter2 dateFromString:string]; };
         }
         
         {
             /*
              Fri Sep 04 00:12:21 +0800 2015 // Weibo, Twitter
+             Fri Sep 04 00:12:21.000 +0800 2015
              */
             NSDateFormatter *formatter = [NSDateFormatter new];
             formatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
             formatter.dateFormat = @"EEE MMM dd HH:mm:ss Z yyyy";
+
+            NSDateFormatter *formatter2 = [NSDateFormatter new];
+            formatter2.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+            formatter2.dateFormat = @"EEE MMM dd HH:mm:ss.SSS Z yyyy";
+
             blocks[30] = ^(NSString *string) { return [formatter dateFromString:string]; };
+            blocks[34] = ^(NSString *string) { return [formatter2 dateFromString:string]; };
         }
     });
     if (!string) return nil;

--- a/YYModelTests/YYTestAutoTypeConvert.m
+++ b/YYModelTests/YYTestAutoTypeConvert.m
@@ -320,6 +320,30 @@
     json = @"{\"v\" : \"Fri Sep 04 00:12:21 +0800 2015\"}";
     model = [YYTestAutoTypeModel yy_modelWithJSON:json];
     XCTAssert([model.date isKindOfClass:[NSDate class]]);
+
+    json = @"{\"v\" : \"2014-05-06 07:08:09.000\"}";
+    model = [YYTestAutoTypeModel yy_modelWithJSON:json];
+    XCTAssert([model.date isKindOfClass:[NSDate class]]);
+
+    json = @"{\"v\" : \"2014-05-06T07:08:09.000\"}";
+    model = [YYTestAutoTypeModel yy_modelWithJSON:json];
+    XCTAssert([model.date isKindOfClass:[NSDate class]]);
+
+    json = @"{\"v\" : \"2014-01-20T12:24:48.000Z\"}";
+    model = [YYTestAutoTypeModel yy_modelWithJSON:json];
+    XCTAssert([model.date isKindOfClass:[NSDate class]]);
+
+    json = @"{\"v\" : \"2014-01-20T12:24:48.000Z\"}";
+    model = [YYTestAutoTypeModel yy_modelWithJSON:json];
+    XCTAssert([model.date isKindOfClass:[NSDate class]]);
+
+    json = @"{\"v\" : \"2014-01-20T12:24:48.000+12:00\"}";
+    model = [YYTestAutoTypeModel yy_modelWithJSON:json];
+    XCTAssert([model.date isKindOfClass:[NSDate class]]);
+
+    json = @"{\"v\" : \"Fri Sep 04 00:12:21.000 +0800 2015\"}";
+    model = [YYTestAutoTypeModel yy_modelWithJSON:json];
+    XCTAssert([model.date isKindOfClass:[NSDate class]]);
     
     model = [YYTestAutoTypeModel yy_modelWithJSON:@{@"v" : [NSDate new]}];
     XCTAssert([model.date isKindOfClass:[NSDate class]]);


### PR DESCRIPTION
Also updated the unit test to test the new supported formats and bumped the version number due to changes.

Dates of length 24 have a conflict, so tries one then the other if it was unsuccessful.