### PR TITLE
refactor: ModelSetValueForProperty函数中的代码一致性 & fix: ModelSetValueForProperty函数中NSData 值类型时，会返回 NSMutableString 给 NSString

### DIFF
--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -776,11 +776,11 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                 case YYEncodingTypeNSString:
                 case YYEncodingTypeNSMutableString: {
                     if ([value isKindOfClass:[NSString class]]) {
-                        if (meta->_nsType == YYEncodingTypeNSString) {
-                            ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, value);
-                        } else {
-                            ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, ((NSString *)value).mutableCopy);
-                        }
+                        ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
+                                                                       meta->_setter,
+                                                                       (meta->_nsType == YYEncodingTypeNSString) ?
+                                                                       value :
+                                                                       ((NSString *)value).mutableCopy);
                     } else if ([value isKindOfClass:[NSNumber class]]) {
                         ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
                                                                        meta->_setter,

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -788,8 +788,11 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                                                                        ((NSNumber *)value).stringValue :
                                                                        ((NSNumber *)value).stringValue.mutableCopy);
                     } else if ([value isKindOfClass:[NSData class]]) {
-                        NSMutableString *string = [[NSMutableString alloc] initWithData:value encoding:NSUTF8StringEncoding];
-                        ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, string);
+                        ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
+                                                                       meta->_setter,
+                                                                       (meta->_nsType == YYEncodingTypeNSString) ?
+                                                                       [[NSString alloc] initWithData:value encoding:NSUTF8StringEncoding] :
+                                                                       [[NSMutableString alloc] initWithData:value encoding:NSUTF8StringEncoding]);
                     } else if ([value isKindOfClass:[NSURL class]]) {
                         ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
                                                                        meta->_setter,


### PR DESCRIPTION
refactor: ModelSetValueForProperty函数中的代码一致性
不知为什么第一处返回 NSString时为何不用与下方一直的  ?: 判断？


fix: ModelSetValueForProperty函数中NSData 值类型时，会返回 NSMutableString 给 NSString
源代码是 直接 init 一个 NSMutableString 返回的，按类型返回可能会好些？ 比较而言多了一个判断。