### PR TITLE
metaWithClass 方法多线程不安全问题

### DIFF
--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -616,15 +616,14 @@ static force_inline id YYValueForMultiKeys(__unsafe_unretained NSDictionary *dic
     });
     dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);
     _YYModelMeta *meta = CFDictionaryGetValue(cache, (__bridge const void *)(cls));
-    dispatch_semaphore_signal(lock);
+
     if (!meta || meta->_classInfo.needUpdate) {
         meta = [[_YYModelMeta alloc] initWithClass:cls];
         if (meta) {
-            dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);
             CFDictionarySetValue(cache, (__bridge const void *)(cls), (__bridge const void *)(meta));
-            dispatch_semaphore_signal(lock);
         }
     }
+    dispatch_semaphore_signal(lock);
     return meta;
 }
 


### PR DESCRIPTION
经过测试发现dispatch_semaphore_signal和dispatch_semaphore_wait逻辑不一定能保证线程真正的安全.

测试方法: 在全局并发队列中异步调用50次metaWithClass方法,传入相同的参数.返回得到的并不是同一个对象