### PR TITLE
由自己喜好来搞的，可能需要作者再整理下

### DIFF
--- a/Benchmark/ModelBenchmark/YYWeiboModel.h
+++ b/Benchmark/ModelBenchmark/YYWeiboModel.h
@@ -16,6 +16,7 @@
 @property (nonatomic, assign) int cutType;
 @end
 
+@protocol YYWeiboPicture;
 @interface YYWeiboPicture : NSObject <NSCoding, NSCopying>
 @property (nonatomic, strong) NSString *picID;
 @property (nonatomic, strong) NSString *objectID;
@@ -29,6 +30,7 @@
 @property (nonatomic, strong) YYWeiboPictureMetadata *original;
 @end
 
+@protocol YYWeiboURL;
 @interface YYWeiboURL : NSObject <NSCoding, NSCopying>
 @property (nonatomic, assign) BOOL result;
 @property (nonatomic, strong) NSString *shortURL;
@@ -118,9 +120,14 @@
 @property (nonatomic, strong) YYWeiboUser *user;
 @property (nonatomic, assign) int32_t userType;
 @property (nonatomic, strong) NSString *text;
-@property (nonatomic, strong) NSArray *picIds;        /// Array<NSString>
-@property (nonatomic, strong) NSDictionary *picInfos; /// Dic<NSString, YYWeiboPicture>
-@property (nonatomic, strong) NSArray *urlStruct;     ///< Array<YYWeiboURL>
+
+@property (nonatomic, strong) NSArray<NSString *><NSString> *picIds;
+@property (nonatomic, strong) NSDictionary<NSString *,YYWeiboPicture *><YYWeiboPicture> *picInfos;
+@property (nonatomic, strong) NSArray<YYWeiboURL *><YYWeiboURL> *urlStruct;
+//@property (nonatomic, strong) NSArray *picIds;        /// Array<NSString>
+//@property (nonatomic, strong) NSDictionary *picInfos; /// Dic<NSString, YYWeiboPicture>
+//@property (nonatomic, strong) NSArray *urlStruct;     ///< Array<YYWeiboURL>
+
 @property (nonatomic, assign) BOOL favorited;
 @property (nonatomic, assign) BOOL truncated;
 @property (nonatomic, assign) int32_t repostsCount;

--- a/Benchmark/ModelBenchmark/YYWeiboModel.h
+++ b/Benchmark/ModelBenchmark/YYWeiboModel.h
@@ -16,7 +16,8 @@
 @property (nonatomic, assign) int cutType;
 @end
 
-@protocol YYWeiboPicture;
+@protocol YYWeiboPicture
+@end
 @interface YYWeiboPicture : NSObject <NSCoding, NSCopying>
 @property (nonatomic, strong) NSString *picID;
 @property (nonatomic, strong) NSString *objectID;
@@ -30,7 +31,8 @@
 @property (nonatomic, strong) YYWeiboPictureMetadata *original;
 @end
 
-@protocol YYWeiboURL;
+@protocol YYWeiboURL
+@end
 @interface YYWeiboURL : NSObject <NSCoding, NSCopying>
 @property (nonatomic, assign) BOOL result;
 @property (nonatomic, strong) NSString *shortURL;

--- a/YYModel/NSObject+YYModel.h
+++ b/YYModel/NSObject+YYModel.h
@@ -430,4 +430,34 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/**
+ YYModelTransformProtocol is an abstract class which provides the
+ basic structure for performing protocol-specific transforming of YYModel.
+ Concrete subclass handles the specifics associated with one or more methods.
+ */
+@interface YYModelTransformProtocol : NSObject
+
+/**
+ This method registers a protocol class, making it visible to several other `YYModelTransformProtocol` class methods.
+ 
+ @param cls A protocol class which must be subclass of `YYModelTransformProtocol` class.
+ */
++ (void)registerClass:(Class)cls;
+
+/**
+ Unregister custom transform center class
+ */
++ (void)unregisterClass;
+
+/**
+ This method's behavior is similar to `+ (nullable NSDictionary<NSString *, id> *)modelCustomPropertyMapper;` of `YYModel` protocol. It returns the additional mapper finally.
+ 
+ @param cls which class is being create mappers.
+ 
+ @return A custom mapper for properties.
+ */
++ (nullable NSDictionary<NSString *, id> *)modelCustomPropertyMapperForClass:(Class)cls;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/YYModel/NSObject+YYModel.h
+++ b/YYModel/NSObject+YYModel.h
@@ -13,6 +13,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+//ns pseudo-generic
+@protocol NSString,NSMutableString,NSValue,NSNumber,NSDecimalNumber,NSData,NSMutableData,NSURL,NSDate;
+
 /**
  Provide some data-model method:
  

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -786,11 +786,11 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                 case YYEncodingTypeNSString:
                 case YYEncodingTypeNSMutableString: {
                     if ([value isKindOfClass:[NSString class]]) {
-                        if (meta->_nsType == YYEncodingTypeNSString) {
-                            ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, value);
-                        } else {
-                            ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, ((NSString *)value).mutableCopy);
-                        }
+                        ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
+                                                                       meta->_setter,
+                                                                       (meta->_nsType == YYEncodingTypeNSString)?
+                                                                       value :
+                                                                       ((NSString *)value).mutableCopy);
                     } else if ([value isKindOfClass:[NSNumber class]]) {
                         ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
                                                                        meta->_setter,
@@ -844,18 +844,18 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                 case YYEncodingTypeNSData:
                 case YYEncodingTypeNSMutableData: {
                     if ([value isKindOfClass:[NSData class]]) {
-                        if (meta->_nsType == YYEncodingTypeNSData) {
-                            ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, value);
-                        } else {
-                            NSMutableData *data = ((NSData *)value).mutableCopy;
-                            ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, data);
-                        }
+                        ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
+                                                                       meta->_setter,
+                                                                       (meta->_nsType == YYEncodingTypeNSData) ?
+                                                                       value :
+                                                                       ((NSData *)value).mutableCopy);
                     } else if ([value isKindOfClass:[NSString class]]) {
                         NSData *data = [(NSString *)value dataUsingEncoding:NSUTF8StringEncoding];
-                        if (meta->_nsType == YYEncodingTypeNSMutableData) {
-                            data = ((NSData *)data).mutableCopy;
-                        }
-                        ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, data);
+                        ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
+                                                                       meta->_setter,
+                                                                       (meta->_nsType == YYEncodingTypeNSData) ?
+                                                                       data :
+                                                                       data.mutableCopy);
                     }
                 } break;
                     
@@ -907,21 +907,17 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                         }
                     } else {
                         if ([value isKindOfClass:[NSArray class]]) {
-                            if (meta->_nsType == YYEncodingTypeNSArray) {
-                                ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, value);
-                            } else {
-                                ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
-                                                                               meta->_setter,
-                                                                               ((NSArray *)value).mutableCopy);
-                            }
+                            ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
+                                                                           meta->_setter,
+                                                                           (meta->_nsType == YYEncodingTypeNSArray) ?
+                                                                           value :
+                                                                           ((NSArray *)value).mutableCopy);
                         } else if ([value isKindOfClass:[NSSet class]]) {
-                            if (meta->_nsType == YYEncodingTypeNSArray) {
-                                ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, ((NSSet *)value).allObjects);
-                            } else {
-                                ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
-                                                                               meta->_setter,
-                                                                               ((NSSet *)value).allObjects.mutableCopy);
-                            }
+                            ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
+                                                                           meta->_setter,
+                                                                           (meta->_nsType == YYEncodingTypeNSArray) ?
+                                                                           ((NSSet *)value).allObjects :
+                                                                           ((NSSet *)value).allObjects.mutableCopy);
                         }
                     }
                 } break;
@@ -945,13 +941,11 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                             }];
                             ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, dic);
                         } else {
-                            if (meta->_nsType == YYEncodingTypeNSDictionary) {
-                                ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, value);
-                            } else {
-                                ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
-                                                                               meta->_setter,
-                                                                               ((NSDictionary *)value).mutableCopy);
-                            }
+                            ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
+                                                                           meta->_setter,
+                                                                           (meta->_nsType == YYEncodingTypeNSDictionary) ?
+                                                                           value :
+                                                                           ((NSDictionary *)value).mutableCopy);
                         }
                     }
                 } break;
@@ -980,13 +974,11 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                         }
                         ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, set);
                     } else {
-                        if (meta->_nsType == YYEncodingTypeNSSet) {
-                            ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, valueSet);
-                        } else {
-                            ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
-                                                                           meta->_setter,
-                                                                           ((NSSet *)valueSet).mutableCopy);
-                        }
+                        ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
+                                                                       meta->_setter,
+                                                                       (meta->_nsType == YYEncodingTypeNSSet) ?
+                                                                       valueSet :
+                                                                       ((NSSet *)valueSet).mutableCopy);
                     }
                 } // break; commented for code coverage in next line
                     

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -348,6 +348,12 @@ static force_inline id YYValueForMultiKeys(__unsafe_unretained NSDictionary *dic
 @implementation _YYModelPropertyMeta
 + (instancetype)metaWithClassInfo:(YYClassInfo *)classInfo propertyInfo:(YYClassPropertyInfo *)propertyInfo generic:(Class)generic {
     _YYModelPropertyMeta *meta = [self new];
+
+    if (!generic && (propertyInfo.type & YYEncodingTypeMask) == YYEncodingTypeObject && propertyInfo.protocolNames.count==1) {
+        //if the only protocolName is a class nams, as the generic class. // pseudo-generic
+        generic = NSClassFromString([propertyInfo.protocolNames firstObject]);
+    }
+    
     meta->_name = propertyInfo.name;
     meta->_type = propertyInfo.type;
     meta->_info = propertyInfo;

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -877,8 +877,11 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                                                                        ((NSNumber *)value).stringValue :
                                                                        ((NSNumber *)value).stringValue.mutableCopy);
                     } else if ([value isKindOfClass:[NSData class]]) {
-                        NSMutableString *string = [[NSMutableString alloc] initWithData:value encoding:NSUTF8StringEncoding];
-                        ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, string);
+                        ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
+                                                                       meta->_setter,
+                                                                       (meta->_nsType == YYEncodingTypeNSString)?
+                                                                       [[NSString alloc] initWithData:value encoding:NSUTF8StringEncoding] :
+                                                                       [[NSMutableString alloc] initWithData:value encoding:NSUTF8StringEncoding]);
                     } else if ([value isKindOfClass:[NSURL class]]) {
                         ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model,
                                                                        meta->_setter,

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -528,7 +528,7 @@ static force_inline id YYValueForMultiKeys(__unsafe_unretained NSDictionary *dic
         }
         curClassInfo = curClassInfo.superClassInfo;
     }
-    if (allPropertyMetas.count) _allPropertyMetas = allPropertyMetas.allValues.copy;
+    if (allPropertyMetas.count>0) _allPropertyMetas = allPropertyMetas.allValues.copy;
     
     // create mapper
     NSMutableDictionary *mapper = [NSMutableDictionary new];
@@ -590,9 +590,9 @@ static force_inline id YYValueForMultiKeys(__unsafe_unretained NSDictionary *dic
         mapper[name] = propertyMeta;
     }];
     
-    if (mapper.count) _mapper = mapper;
-    if (keyPathPropertyMetas) _keyPathPropertyMetas = keyPathPropertyMetas;
-    if (multiKeysPropertyMetas) _multiKeysPropertyMetas = multiKeysPropertyMetas;
+    if (mapper.count>0) _mapper = mapper;
+    if (keyPathPropertyMetas.count>0) _keyPathPropertyMetas = keyPathPropertyMetas;
+    if (multiKeysPropertyMetas.count>0) _multiKeysPropertyMetas = multiKeysPropertyMetas;
     
     _classInfo = classInfo;
     _keyMappedCount = _allPropertyMetas.count;

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -1102,7 +1102,7 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                         Class cls = meta->_cls;
                         if (meta->_hasCustomClassFromDictionary) {
                             cls = [cls modelCustomClassForDictionary:value];
-                            if (!cls) cls = meta->_genericCls; // for xcode code coverage
+                            if (!cls) cls = meta->_cls; // for xcode code coverage
                         }
                         one = [cls new];
                         [one yy_modelSetWithDictionary:value];

--- a/YYModel/YYClassInfo.h
+++ b/YYModel/YYClassInfo.h
@@ -14,6 +14,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#define YYMODEL_THREAD_ASSERT_ON_ERROR(x_) do { \
+_Pragma("clang diagnostic push"); \
+_Pragma("clang diagnostic ignored \"-Wunused-variable\""); \
+volatile int res = (x_); \
+assert(res == 0); \
+_Pragma("clang diagnostic pop"); \
+} while (0)
+
 /**
  Type encoding's type.
  */

--- a/YYModel/YYClassInfo.h
+++ b/YYModel/YYClassInfo.h
@@ -136,6 +136,7 @@ YYEncodingType YYEncodingGetType(const char *typeEncoding);
 @property (nonatomic, strong, readonly) NSString *typeEncoding;   ///< property's encoding value
 @property (nonatomic, strong, readonly) NSString *ivarName;       ///< property's ivar name
 @property (nullable, nonatomic, assign, readonly) Class cls;      ///< may be nil
+@property (nullable, nonatomic, strong, readonly) Protocol *protocol; ///< may be nil
 @property (nonatomic, assign, readonly) SEL getter;               ///< getter (nonnull)
 @property (nonatomic, assign, readonly) SEL setter;               ///< setter (nonnull)
 

--- a/YYModel/YYClassInfo.h
+++ b/YYModel/YYClassInfo.h
@@ -136,7 +136,8 @@ YYEncodingType YYEncodingGetType(const char *typeEncoding);
 @property (nonatomic, strong, readonly) NSString *typeEncoding;   ///< property's encoding value
 @property (nonatomic, strong, readonly) NSString *ivarName;       ///< property's ivar name
 @property (nullable, nonatomic, assign, readonly) Class cls;      ///< may be nil
-@property (nullable, nonatomic, strong, readonly) Protocol *protocol; ///< may be nil
+@property (nullable, nonatomic, strong, readonly) NSArray *protocolNames; ///< may be nil
+
 @property (nonatomic, assign, readonly) SEL getter;               ///< getter (nonnull)
 @property (nonatomic, assign, readonly) SEL setter;               ///< setter (nonnull)
 

--- a/YYModel/YYClassInfo.h
+++ b/YYModel/YYClassInfo.h
@@ -206,4 +206,68 @@ YYEncodingType YYEncodingGetType(const char *typeEncoding);
 
 @end
 
+/**
+ Provide some method to tell all property infos or whether a given property key is present in the class(or its superclass)
+ */
+@interface NSObject (YYClassInfo)
+
+/**
+ Returns a Boolean value that indicates whether a given property key is present in the class(or its superclass). The method will ignore the properties of [NSObject class].
+ 
+ @param propertyKey a property key maybe exist
+ 
+ @return YES if property key is present in the class, otherwise NO.
+ */
++ (BOOL)yy_containsPropertyKey:(NSString*)propertyKey;
+
+/**
+ Returns a Boolean value that indicates whether a given property key is present in the class(or its superclass). The method will not ignore the properties of untilCls.
+ 
+ @param propertyKey a property key maybe exist
+ @param untilCls the last superclass which will be not ignored
+ 
+ @return YES if property key is present in the class, otherwise NO.
+ */
++ (BOOL)yy_containsPropertyKey:(NSString*)propertyKey untilClass:(Class)untilCls;
+
+/**
+ Returns a Boolean value that indicates whether a given property key is present in the class(or its superclass).
+ 
+ @param propertyKey a property key maybe exist
+ @param untilCls the last superclass which will be ignored or not
+ @param ignoreUntilCls indicates whether the untilCls will be ignored
+ 
+ @return YES if property key is present in the class, otherwise NO.
+ */
++ (BOOL)yy_containsPropertyKey:(NSString*)propertyKey untilClass:(Class)untilCls ignoreUntilClass:(BOOL)ignoreUntilCls;
+
+/**
+ Returns all property infos in the class(or its superclass). The method will ignore the properties of [NSObject class].
+ 
+ @return all property infos
+ */
++ (nullable NSDictionary<NSString *, YYClassPropertyInfo *> *)yy_propertyInfos;
+
+/**
+ Returns all property infos in the class(or its superclass). The method will not ignore the properties of untilCls.
+ 
+ @param untilCls the last superclass which will be not ignored
+ 
+ @return all property infos
+ */
++ (nullable NSDictionary<NSString *, YYClassPropertyInfo *> *)yy_propertyInfosUntilClass:(Class)untilCls;
+
+/**
+ Returns all property infos in the class(or its superclass).
+ 
+ @param propertyKey a property key maybe exist
+ @param untilCls the last superclass which will be ignored or not
+ @param ignoreUntilCls indicates whether the untilCls will be ignored
+ 
+ @return all property infos
+ */
++ (nullable NSDictionary<NSString *, YYClassPropertyInfo *> *)yy_propertyInfosUntilClass:(Class)untilCls ignoreUntilClass:(BOOL)ignoreUntilCls;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/YYModel/YYClassInfo.m
+++ b/YYModel/YYClassInfo.m
@@ -389,3 +389,56 @@ static pthread_rwlock_t yymodel_rwlock;
 }
 
 @end
+
+@implementation NSObject (YYClassInfo)
+
++ (BOOL)yy_containsPropertyKey:(NSString*)propertyKey
+{
+    return [self yy_containsPropertyKey:propertyKey untilClass:[NSObject class] ignoreUntilClass:YES];
+}
+
++ (BOOL)yy_containsPropertyKey:(NSString*)propertyKey untilClass:(Class)untilCls
+{
+    return [self yy_containsPropertyKey:propertyKey untilClass:untilCls ignoreUntilClass:NO];
+}
+
++ (BOOL)yy_containsPropertyKey:(NSString*)propertyKey untilClass:(Class)untilCls ignoreUntilClass:(BOOL)ignoreUntilCls
+{
+    NSDictionary<NSString *, YYClassPropertyInfo *> *propertyInfos = [self yy_propertyInfosUntilClass:untilCls ignoreUntilClass:ignoreUntilCls];
+    return (propertyInfos[propertyKey]!=nil);
+}
+
++ (NSDictionary<NSString *, YYClassPropertyInfo *> *)yy_propertyInfos
+{
+    return [self yy_propertyInfosUntilClass:[NSObject class] ignoreUntilClass:YES];
+}
+
++ (NSDictionary<NSString *, YYClassPropertyInfo *> *)yy_propertyInfosUntilClass:(Class)untilCls
+{
+    return [self yy_propertyInfosUntilClass:untilCls ignoreUntilClass:NO];
+}
+
++ (NSDictionary<NSString *, YYClassPropertyInfo *> *)yy_propertyInfosUntilClass:(Class)untilCls ignoreUntilClass:(BOOL)ignoreUntilCls
+{
+    NSAssert(untilCls, @"The `cls` param of yy_propertyInfosUntilClass:ignoreUntilClass: cant be nil!");
+    NSAssert([[self class] isSubclassOfClass:untilCls], @"%@ is not the subclass of %@",NSStringFromClass([self class]),NSStringFromClass(untilCls));
+    
+    YYClassInfo *classInfo = [YYClassInfo classInfoWithClass:[self class]];
+    if (!classInfo) return nil;
+    
+    NSMutableDictionary<NSString *, YYClassPropertyInfo *> *allPropertyInfos = [NSMutableDictionary<NSString *, YYClassPropertyInfo *> dictionary];
+    Class ignoreClass = ignoreUntilCls?untilCls:[untilCls superclass];//if cls is [NSObject class],its superclass is nil
+    
+    YYClassInfo *curClassInfo = classInfo;
+    while (curClassInfo && curClassInfo.cls != ignoreClass) {
+        for (YYClassPropertyInfo *propertyInfo in curClassInfo.propertyInfos.allValues) {
+            if (!propertyInfo.name || allPropertyInfos[propertyInfo.name]) continue; //If contains the same key, subclass is preferred.
+            allPropertyInfos[propertyInfo.name] = propertyInfo;
+        }
+        curClassInfo = curClassInfo.superClassInfo;
+    }
+    
+    return allPropertyInfos.count>0?allPropertyInfos:nil;
+}
+
+@end

--- a/YYModel/YYClassInfo.m
+++ b/YYModel/YYClassInfo.m
@@ -177,17 +177,22 @@ YYEncodingType YYEncodingGetType(const char *typeEncoding) {
                             name[len - 1] = '\0';
                             memcpy(name, attrs[i].value + 2, len - 1);
                             
-                            //It has protocol when the final char is >.
+                            //It has protocols if the final char is >.
+                            //if multi protocols, the name maybe is NSMutableArray<Pig><Dog><Cat>
                             if (name[len - 2] == '>') {
                                 name[len - 2] = '\0';
                                 char *p = strchr(name, '<');
                                 if (p != NULL) {
                                     p[0] = '\0';
-                                    p++;
                                     _cls = objc_getClass(name);
                                     
+                                    p++;
+                                    //p maybe contain multi protocol names. maybe is Pig><Dog><Cat
+                                    //and if one protocol is not adopted(or used), objc_getProtocol(p) would return nil
                                     //see http://stackoverflow.com/questions/10212119/objc-getprotocol-returns-null-for-nsapplicationdelegate
-                                    _protocol = objc_getProtocol(p);
+                                    //so we just record the protocol names
+                                    NSString *pNames = [NSString stringWithUTF8String:p];
+                                    _protocolNames = [pNames componentsSeparatedByString:@"><"];
                                 }
                             }else{
                                 _cls = objc_getClass(name);

--- a/YYModelTests/YYTestClassInfo.m
+++ b/YYModelTests/YYTestClassInfo.m
@@ -79,8 +79,21 @@ typedef union yy_union{ char a; int b;} yy_union;
 @end
 
 
+@protocol Pig
+@end
+@protocol Egg
+@end
+@protocol Dog
+@end
 
+@interface YYTestPropertySubModel : YYTestPropertyModel
 
+@property (nonatomic, strong) NSString<Pig,Egg,Dog> *randomValue;
+
+@end
+
+@implementation YYTestPropertySubModel
+@end
 
 
 @interface YYTestClassInfo : XCTestCase
@@ -175,6 +188,27 @@ typedef union yy_union{ char a; int b;} yy_union;
     XCTAssert([self getType:info name:@"dynamicValue"] & YYEncodingTypePropertyMask & YYEncodingTypePropertyDynamic);
     XCTAssert([self getType:info name:@"getterValue"] & YYEncodingTypePropertyMask &YYEncodingTypePropertyCustomGetter);
     XCTAssert([self getType:info name:@"setterValue"] & YYEncodingTypePropertyMask & YYEncodingTypePropertyCustomSetter);
+}
+
+- (void)testOthers {
+    //contain property key
+    XCTAssert([YYTestPropertyModel yy_containsPropertyKey:@"boolValue"]);
+    XCTAssert(![YYTestPropertyModel yy_containsPropertyKey:@"boolValue" untilClass:[YYTestPropertyModel class] ignoreUntilClass:YES]);
+    XCTAssert(![YYTestPropertySubModel yy_containsPropertyKey:@"boolValue" untilClass:[YYTestPropertySubModel class]]);
+    XCTAssert([YYTestPropertySubModel yy_containsPropertyKey:@"boolValue" untilClass:[YYTestPropertyModel class]]);
+    XCTAssert(![YYTestPropertySubModel yy_containsPropertyKey:@"boolValue" untilClass:[YYTestPropertyModel class] ignoreUntilClass:YES]);
+    
+    //propertyInfos
+    XCTAssert([YYTestPropertySubModel yy_propertyInfos][@"boolValue"]);
+    XCTAssert([YYTestPropertySubModel yy_propertyInfosUntilClass:[YYTestPropertySubModel class]][@"randomValue"]);
+    XCTAssert(![YYTestPropertySubModel yy_propertyInfosUntilClass:[YYTestPropertyModel class] ignoreUntilClass:YES][@"boolValue"]);
+    
+    //protocol names
+    YYClassInfo *info = [YYClassInfo classInfoWithClass:[YYTestPropertySubModel class]];
+    YYClassPropertyInfo *propertyInfo = info.propertyInfos[@"randomValue"];
+    XCTAssert([propertyInfo.protocolNames containsObject:@"Pig"]);
+    XCTAssert([propertyInfo.protocolNames containsObject:@"Egg"]);
+    XCTAssert([propertyInfo.protocolNames containsObject:@"Dog"]);
 }
 
 - (YYEncodingType)getType:(YYClassInfo *)info name:(NSString *)name {

--- a/YYModelTests/YYTestModelMapper.m
+++ b/YYModelTests/YYTestModelMapper.m
@@ -180,7 +180,7 @@
     
     model = [YYTestPropertyMapperModelContainer yy_modelWithJSON:json];
     XCTAssertTrue([model.array isKindOfClass:[NSArray class]]);
-    XCTAssertTrue(model.array.count == 4);
+    XCTAssertTrue(model.array.count == 3);
     
     jsonObject = [model yy_modelToJSONObject];
     XCTAssertTrue([jsonObject[@"array"] isKindOfClass:[NSArray class]]);
@@ -201,7 +201,7 @@
     
     model = [YYTestPropertyMapperModelContainer yy_modelWithJSON:json];
     XCTAssertTrue([model.dict isKindOfClass:[NSDictionary class]]);
-    XCTAssertTrue(model.dict.count == 4);
+    XCTAssertTrue(model.dict.count == 3);
     
     jsonObject = [model yy_modelToJSONObject];
     XCTAssertTrue(jsonObject != nil);
@@ -222,7 +222,7 @@
     
     model = [YYTestPropertyMapperModelContainer yy_modelWithJSON:json];
     XCTAssertTrue([model.set isKindOfClass:[NSSet class]]);
-    XCTAssertTrue(model.set.count == 4);
+    XCTAssertTrue(model.set.count == 3);
     
     jsonObject = [model yy_modelToJSONObject];
     XCTAssertTrue(jsonObject != nil);


### PR DESCRIPTION
修复和添加的东西:
- setNeedUpdate呢，现在是非线程安全的，这个方法应该和_update方法互斥才可以。我那边是比较装逼的搞了俩读写锁，被这东西也折腾的要死要活的，经过代码测试，应该没问题。
- 一些判断是否mutable的地方呢，有的是if/else有的是三元运算符，我看着实在难受，就统一了下。
- 当属性类型被标记protocol的时候 例如 `@property (nonatomic, strong) NSMutableSet<Pig,Dog,Cat> *pigs;`的时候获取的typeEncoding会是`@"NSMutableSet<Pig><Dog><Cat>"`，最终ClassInfo给cls属性赋值那块没处理这种，结果就不对了。
- 伪泛型作为genericClass https://github.com/ibireme/YYModel/issues/79 ，但是这个东西刚才发现比较操蛋的一点就是例如一个Model里对应的类型打比方是NSArray<Pig>，那手动对其赋值时候，也得用<Pig>标记的编译器才不会警告，当然这样对代码可读性很好，就是写起来操蛋，手动赋值的需求似乎也很少。
当然这东西还是愿意用的用，不愿意用的不用，又不冲突。。
- https://github.com/ibireme/YYModel/issues/106 所有的容器类里的NSNull元素将被抛弃。经过测试：现有YYModel里如果容器类有genericClass的话NSNull元素就会被忽略，没的话就不忽略，这行为没统一不太正常。
- `YYModelTransformProtocol`一个自定义映射中心类的东西，说白了也就是处理下 id->ID 这样的牵扯到关键字的转换，只会放一些极其特殊的，多了太影响性能。因为我参与过的项目都是驼峰法，还需要自己去重复写映射关系我觉得是件挺二的事情，之前我的项目里的Model转换是大小写不敏感的，像id这种，我改个大小写就能用，但不敏感性价比太差，所以参考`NSURLProtocol`的方式搞了个抽象类，例如 `MLTransformProtocol`继承`YYModelTransformProtocol`实现转换方法，`[YYModelTransformProtocol registerClass:[MLTransformProtocol class]];`，线程安全的，实现方式或许还有待商榷，但我觉得这东西还是有必要的。
- 在`YYClassInfo`文件里添加了 `NSObject (YYClassInfo)` 。里面是我觉得项目里可能还稍微常用的获取某类的所有属性信息(包括父类)，和判断某类里是否具有名为xxx的属性(包括父类)。

一开始Test出错一次 `YYTestModelMapper.m`里的`testContainer`方法，由于NSNull问题，我把4都改成3了。
还有就是英文实在很差，那注释我自己都看不下去。

改的东西太多，估计可能有你不喜欢的，不合并也没事，交流学习，基本上我想加的也加完了。:)