### PR TITLE
当属性定义有Protocol时， 所有的转换都会出错的，可以看新增的测试用例。

### DIFF
--- a/YYModel/YYClassInfo.m
+++ b/YYModel/YYClassInfo.m
@@ -169,12 +169,16 @@ YYEncodingType YYEncodingGetType(const char *typeEncoding) {
                     _typeEncoding = [NSString stringWithUTF8String:attrs[i].value];
                     type = YYEncodingGetType(attrs[i].value);
                     if ((type & YYEncodingTypeMask) == YYEncodingTypeObject) {
-                        size_t len = strlen(attrs[i].value);
-                        if (len > 3) {
-                            char name[len - 2];
-                            name[len - 3] = '\0';
-                            memcpy(name, attrs[i].value + 2, len - 3);
-                            _cls = objc_getClass(name);
+                        NSInteger toRight = [_typeEncoding rangeOfString:@"<"].location;
+                        if (toRight != NSNotFound) {
+                            toRight = toRight - 2;
+                        }
+                        else {
+                            toRight = _typeEncoding.length - 3;
+                        }
+                        if (toRight > 0) {
+                            NSString* className = [_typeEncoding substringWithRange:NSMakeRange(2, toRight)];
+                            _cls = NSClassFromString(className);
                         }
                     }
                 }

--- a/YYModelTests/YYTestModelMapper.m
+++ b/YYModelTests/YYTestModelMapper.m
@@ -54,14 +54,17 @@
 @synthesize description = _description;
 @end
 
+@protocol AProtocol
+@end
 
 @interface YYTestPropertyMapperModelContainer : NSObject
-@property (nonatomic, strong) NSArray *array;
+@property (nonatomic, strong) NSArray<AProtocol> *array;
 @property (nonatomic, strong) NSMutableArray *mArray;
-@property (nonatomic, strong) NSDictionary *dict;
+@property (nonatomic, strong) NSDictionary<AProtocol> *dict;
 @property (nonatomic, strong) NSMutableDictionary *mDict;
-@property (nonatomic, strong) NSSet *set;
+@property (nonatomic, strong) NSSet<AProtocol> *set;
 @property (nonatomic, strong) NSMutableSet *mSet;
+@property (nonatomic, strong) YYTestPropertyMapperModelAuto<AProtocol>* autoModel;
 @end
 
 @implementation YYTestPropertyMapperModelContainer
@@ -179,6 +182,12 @@
     NSString *json;
     NSDictionary *jsonObject = nil;
     YYTestPropertyMapperModelContainer *model;
+    
+    json = @"{\"autoModel\":{\"name\":\"Apple\", \"count\":10}}";
+    model = [YYTestPropertyMapperModelContainerGeneric yy_modelWithJSON:json];
+    XCTAssertTrue([model.autoModel isKindOfClass:[YYTestPropertyMapperModelAuto class]]);
+    XCTAssertTrue([model.autoModel.name isEqualToString:@"Apple"]);
+    XCTAssertTrue([model.autoModel.count isEqual:@10]);
     
     json = @"{\"array\":[\n  {\"name\":\"Apple\", \"count\":10},\n  {\"name\":\"Banana\", \"count\":11},\n  {\"name\":\"Pear\", \"count\":12},\n  null\n]}";
     


### PR DESCRIPTION
解决方法是获取 Property Type Class 时，把Protocol定义过滤掉。