### PR TITLE
[bugfix] yy_modelIsEqual

### DIFF
--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -1758,7 +1758,7 @@ static NSString *ModelDescription(NSObject *model) {
         id this = [self valueForKey:NSStringFromSelector(propertyMeta->_getter)];
         id that = [model valueForKey:NSStringFromSelector(propertyMeta->_getter)];
         if (this == that) continue;
-        if (this == nil || that == nil) return NO;
+        if (this == nil ^ that == nil) return NO;
         if (![this isEqual:that]) return NO;
     }
     return YES;


### PR DESCRIPTION
两个属性都等于nil的时候不应该返回NO