### PR TITLE
add some useful method to YYModel

### DIFF
--- a/Benchmark/ModelBenchmark.xcodeproj/project.pbxproj
+++ b/Benchmark/ModelBenchmark.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4D2ACEC51EA8416600D3A8AB /* NSString+YYModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D2ACEC41EA8416600D3A8AB /* NSString+YYModel.m */; };
 		D9B193811BAC714D00F93933 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D9B193801BAC714D00F93933 /* main.m */; };
 		D9B193841BAC714D00F93933 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D9B193831BAC714D00F93933 /* AppDelegate.m */; };
 		D9B193871BAC714D00F93933 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D9B193861BAC714D00F93933 /* ViewController.m */; };
@@ -22,63 +23,63 @@
 		D9B194841BAC737000F93933 /* MJWeiboModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D9B1947B1BAC737000F93933 /* MJWeiboModel.m */; };
 		D9B194851BAC737000F93933 /* user.json in Resources */ = {isa = PBXBuildFile; fileRef = D9B1947C1BAC737000F93933 /* user.json */; };
 		D9B194861BAC737000F93933 /* weibo.json in Resources */ = {isa = PBXBuildFile; fileRef = D9B1947D1BAC737000F93933 /* weibo.json */; };
-		D9EB031C1BD5F96100B3E0F5 /* Cartfile.bak in Resources */ = {isa = PBXBuildFile; fileRef = D9EB031B1BD5F96100B3E0F5 /* Cartfile.bak */; settings = {ASSET_TAGS = (); }; };
-		D9EB032A1BD64C3200B3E0F5 /* NSObject+YYModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03261BD64C3200B3E0F5 /* NSObject+YYModel.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB032B1BD64C3200B3E0F5 /* YYClassInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03281BD64C3200B3E0F5 /* YYClassInfo.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03DC1BD64D1E00B3E0F5 /* FEMAssignmentPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03531BD64D1D00B3E0F5 /* FEMAssignmentPolicy.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03DD1BD64D1E00B3E0F5 /* FEMRelationshipAssignmentContext.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03561BD64D1D00B3E0F5 /* FEMRelationshipAssignmentContext.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03DE1BD64D1E00B3E0F5 /* FEMManagedObjectCache.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03591BD64D1D00B3E0F5 /* FEMManagedObjectCache.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03DF1BD64D1E00B3E0F5 /* FEMDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB035C1BD64D1D00B3E0F5 /* FEMDeserializer.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03E01BD64D1E00B3E0F5 /* FEMAttribute.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03611BD64D1D00B3E0F5 /* FEMAttribute.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03E11BD64D1E00B3E0F5 /* FEMMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03641BD64D1D00B3E0F5 /* FEMMapping.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03E21BD64D1E00B3E0F5 /* FEMRelationship.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03681BD64D1D00B3E0F5 /* FEMRelationship.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03E31BD64D1E00B3E0F5 /* FEMSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB036B1BD64D1D00B3E0F5 /* FEMSerializer.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03E41BD64D1E00B3E0F5 /* FEMManagedObjectStore.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB036E1BD64D1D00B3E0F5 /* FEMManagedObjectStore.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03E51BD64D1E00B3E0F5 /* FEMObjectStore.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03701BD64D1D00B3E0F5 /* FEMObjectStore.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03E61BD64D1E00B3E0F5 /* FEMExcludableCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03741BD64D1D00B3E0F5 /* FEMExcludableCollection.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03E71BD64D1E00B3E0F5 /* FEMMergeableCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03761BD64D1D00B3E0F5 /* FEMMergeableCollection.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03E81BD64D1E00B3E0F5 /* NSArray+FEMPropertyRepresentation.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03791BD64D1D00B3E0F5 /* NSArray+FEMPropertyRepresentation.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03E91BD64D1E00B3E0F5 /* NSObject+FEMKVCExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB037B1BD64D1D00B3E0F5 /* NSObject+FEMKVCExtension.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03EA1BD64D1E00B3E0F5 /* FEMMappingUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB037F1BD64D1D00B3E0F5 /* FEMMappingUtility.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03EB1BD64D1E00B3E0F5 /* FEMRepresentationUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03811BD64D1D00B3E0F5 /* FEMRepresentationUtility.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03EC1BD64D1E00B3E0F5 /* FEMTypeIntrospection.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03831BD64D1D00B3E0F5 /* FEMTypeIntrospection.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03ED1BD64D1E00B3E0F5 /* JSONModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03881BD64D1D00B3E0F5 /* JSONModel.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03EE1BD64D1E00B3E0F5 /* JSONModelArray.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB038A1BD64D1D00B3E0F5 /* JSONModelArray.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03EF1BD64D1E00B3E0F5 /* JSONModelClassProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB038C1BD64D1D00B3E0F5 /* JSONModelClassProperty.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03F01BD64D1E00B3E0F5 /* JSONModelError.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB038E1BD64D1D00B3E0F5 /* JSONModelError.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03F11BD64D1E00B3E0F5 /* NSArray+JSONModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03911BD64D1D00B3E0F5 /* NSArray+JSONModel.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03F21BD64D1E00B3E0F5 /* JSONAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03951BD64D1D00B3E0F5 /* JSONAPI.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03F31BD64D1E00B3E0F5 /* JSONHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03971BD64D1D00B3E0F5 /* JSONHTTPClient.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03F41BD64D1E00B3E0F5 /* JSONModel+networking.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03991BD64D1D00B3E0F5 /* JSONModel+networking.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03F51BD64D1E00B3E0F5 /* JSONKeyMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB039C1BD64D1D00B3E0F5 /* JSONKeyMapper.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03F61BD64D1E00B3E0F5 /* JSONValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB039E1BD64D1D00B3E0F5 /* JSONValueTransformer.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03F71BD64D1E00B3E0F5 /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03A31BD64D1D00B3E0F5 /* EXTRuntimeExtensions.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03F81BD64D1E00B3E0F5 /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03A51BD64D1D00B3E0F5 /* EXTScope.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03F91BD64D1E00B3E0F5 /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03A91BD64D1D00B3E0F5 /* MTLJSONAdapter.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03FA1BD64D1E00B3E0F5 /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03AB1BD64D1D00B3E0F5 /* MTLModel+NSCoding.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03FB1BD64D1E00B3E0F5 /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03AD1BD64D1D00B3E0F5 /* MTLModel.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03FC1BD64D1E00B3E0F5 /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03AF1BD64D1D00B3E0F5 /* MTLReflection.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03FD1BD64D1E00B3E0F5 /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03B11BD64D1D00B3E0F5 /* MTLTransformerErrorHandling.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03FE1BD64D1E00B3E0F5 /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03B31BD64D1D00B3E0F5 /* MTLValueTransformer.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB03FF1BD64D1E00B3E0F5 /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03B51BD64D1D00B3E0F5 /* NSArray+MTLManipulationAdditions.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB04001BD64D1E00B3E0F5 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03B71BD64D1D00B3E0F5 /* NSDictionary+MTLJSONKeyPath.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB04011BD64D1E00B3E0F5 /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03B91BD64D1D00B3E0F5 /* NSDictionary+MTLManipulationAdditions.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB04021BD64D1E00B3E0F5 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03BB1BD64D1D00B3E0F5 /* NSDictionary+MTLMappingAdditions.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB04031BD64D1E00B3E0F5 /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03BD1BD64D1D00B3E0F5 /* NSError+MTLModelException.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB04041BD64D1E00B3E0F5 /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03BF1BD64D1D00B3E0F5 /* NSObject+MTLComparisonAdditions.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB04051BD64D1E00B3E0F5 /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03C11BD64D1D00B3E0F5 /* NSValueTransformer+MTLInversionAdditions.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB04061BD64D1E00B3E0F5 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03C31BD64D1E00B3E0F5 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB04071BD64D1E00B3E0F5 /* MJDictionaryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03C61BD64D1E00B3E0F5 /* MJDictionaryCache.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB04081BD64D1E00B3E0F5 /* MJExtensionConst.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03C91BD64D1E00B3E0F5 /* MJExtensionConst.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB04091BD64D1E00B3E0F5 /* MJFoundation.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03CB1BD64D1E00B3E0F5 /* MJFoundation.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB040A1BD64D1E00B3E0F5 /* MJProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03CD1BD64D1E00B3E0F5 /* MJProperty.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB040B1BD64D1E00B3E0F5 /* MJPropertyKey.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03CF1BD64D1E00B3E0F5 /* MJPropertyKey.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB040C1BD64D1E00B3E0F5 /* MJPropertyType.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03D11BD64D1E00B3E0F5 /* MJPropertyType.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB040D1BD64D1E00B3E0F5 /* NSObject+MJClass.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03D31BD64D1E00B3E0F5 /* NSObject+MJClass.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB040E1BD64D1E00B3E0F5 /* NSObject+MJCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03D51BD64D1E00B3E0F5 /* NSObject+MJCoding.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB040F1BD64D1E00B3E0F5 /* NSObject+MJKeyValue.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03D71BD64D1E00B3E0F5 /* NSObject+MJKeyValue.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB04101BD64D1E00B3E0F5 /* NSObject+MJProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03D91BD64D1E00B3E0F5 /* NSObject+MJProperty.m */; settings = {ASSET_TAGS = (); }; };
-		D9EB04111BD64D1E00B3E0F5 /* NSString+MJExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03DB1BD64D1E00B3E0F5 /* NSString+MJExtension.m */; settings = {ASSET_TAGS = (); }; };
+		D9EB031C1BD5F96100B3E0F5 /* Cartfile.bak in Resources */ = {isa = PBXBuildFile; fileRef = D9EB031B1BD5F96100B3E0F5 /* Cartfile.bak */; };
+		D9EB032A1BD64C3200B3E0F5 /* NSObject+YYModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03261BD64C3200B3E0F5 /* NSObject+YYModel.m */; };
+		D9EB032B1BD64C3200B3E0F5 /* YYClassInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03281BD64C3200B3E0F5 /* YYClassInfo.m */; };
+		D9EB03DC1BD64D1E00B3E0F5 /* FEMAssignmentPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03531BD64D1D00B3E0F5 /* FEMAssignmentPolicy.m */; };
+		D9EB03DD1BD64D1E00B3E0F5 /* FEMRelationshipAssignmentContext.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03561BD64D1D00B3E0F5 /* FEMRelationshipAssignmentContext.m */; };
+		D9EB03DE1BD64D1E00B3E0F5 /* FEMManagedObjectCache.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03591BD64D1D00B3E0F5 /* FEMManagedObjectCache.m */; };
+		D9EB03DF1BD64D1E00B3E0F5 /* FEMDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB035C1BD64D1D00B3E0F5 /* FEMDeserializer.m */; };
+		D9EB03E01BD64D1E00B3E0F5 /* FEMAttribute.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03611BD64D1D00B3E0F5 /* FEMAttribute.m */; };
+		D9EB03E11BD64D1E00B3E0F5 /* FEMMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03641BD64D1D00B3E0F5 /* FEMMapping.m */; };
+		D9EB03E21BD64D1E00B3E0F5 /* FEMRelationship.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03681BD64D1D00B3E0F5 /* FEMRelationship.m */; };
+		D9EB03E31BD64D1E00B3E0F5 /* FEMSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB036B1BD64D1D00B3E0F5 /* FEMSerializer.m */; };
+		D9EB03E41BD64D1E00B3E0F5 /* FEMManagedObjectStore.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB036E1BD64D1D00B3E0F5 /* FEMManagedObjectStore.m */; };
+		D9EB03E51BD64D1E00B3E0F5 /* FEMObjectStore.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03701BD64D1D00B3E0F5 /* FEMObjectStore.m */; };
+		D9EB03E61BD64D1E00B3E0F5 /* FEMExcludableCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03741BD64D1D00B3E0F5 /* FEMExcludableCollection.m */; };
+		D9EB03E71BD64D1E00B3E0F5 /* FEMMergeableCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03761BD64D1D00B3E0F5 /* FEMMergeableCollection.m */; };
+		D9EB03E81BD64D1E00B3E0F5 /* NSArray+FEMPropertyRepresentation.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03791BD64D1D00B3E0F5 /* NSArray+FEMPropertyRepresentation.m */; };
+		D9EB03E91BD64D1E00B3E0F5 /* NSObject+FEMKVCExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB037B1BD64D1D00B3E0F5 /* NSObject+FEMKVCExtension.m */; };
+		D9EB03EA1BD64D1E00B3E0F5 /* FEMMappingUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB037F1BD64D1D00B3E0F5 /* FEMMappingUtility.m */; };
+		D9EB03EB1BD64D1E00B3E0F5 /* FEMRepresentationUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03811BD64D1D00B3E0F5 /* FEMRepresentationUtility.m */; };
+		D9EB03EC1BD64D1E00B3E0F5 /* FEMTypeIntrospection.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03831BD64D1D00B3E0F5 /* FEMTypeIntrospection.m */; };
+		D9EB03ED1BD64D1E00B3E0F5 /* JSONModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03881BD64D1D00B3E0F5 /* JSONModel.m */; };
+		D9EB03EE1BD64D1E00B3E0F5 /* JSONModelArray.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB038A1BD64D1D00B3E0F5 /* JSONModelArray.m */; };
+		D9EB03EF1BD64D1E00B3E0F5 /* JSONModelClassProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB038C1BD64D1D00B3E0F5 /* JSONModelClassProperty.m */; };
+		D9EB03F01BD64D1E00B3E0F5 /* JSONModelError.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB038E1BD64D1D00B3E0F5 /* JSONModelError.m */; };
+		D9EB03F11BD64D1E00B3E0F5 /* NSArray+JSONModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03911BD64D1D00B3E0F5 /* NSArray+JSONModel.m */; };
+		D9EB03F21BD64D1E00B3E0F5 /* JSONAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03951BD64D1D00B3E0F5 /* JSONAPI.m */; };
+		D9EB03F31BD64D1E00B3E0F5 /* JSONHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03971BD64D1D00B3E0F5 /* JSONHTTPClient.m */; };
+		D9EB03F41BD64D1E00B3E0F5 /* JSONModel+networking.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03991BD64D1D00B3E0F5 /* JSONModel+networking.m */; };
+		D9EB03F51BD64D1E00B3E0F5 /* JSONKeyMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB039C1BD64D1D00B3E0F5 /* JSONKeyMapper.m */; };
+		D9EB03F61BD64D1E00B3E0F5 /* JSONValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB039E1BD64D1D00B3E0F5 /* JSONValueTransformer.m */; };
+		D9EB03F71BD64D1E00B3E0F5 /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03A31BD64D1D00B3E0F5 /* EXTRuntimeExtensions.m */; };
+		D9EB03F81BD64D1E00B3E0F5 /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03A51BD64D1D00B3E0F5 /* EXTScope.m */; };
+		D9EB03F91BD64D1E00B3E0F5 /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03A91BD64D1D00B3E0F5 /* MTLJSONAdapter.m */; };
+		D9EB03FA1BD64D1E00B3E0F5 /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03AB1BD64D1D00B3E0F5 /* MTLModel+NSCoding.m */; };
+		D9EB03FB1BD64D1E00B3E0F5 /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03AD1BD64D1D00B3E0F5 /* MTLModel.m */; };
+		D9EB03FC1BD64D1E00B3E0F5 /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03AF1BD64D1D00B3E0F5 /* MTLReflection.m */; };
+		D9EB03FD1BD64D1E00B3E0F5 /* MTLTransformerErrorHandling.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03B11BD64D1D00B3E0F5 /* MTLTransformerErrorHandling.m */; };
+		D9EB03FE1BD64D1E00B3E0F5 /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03B31BD64D1D00B3E0F5 /* MTLValueTransformer.m */; };
+		D9EB03FF1BD64D1E00B3E0F5 /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03B51BD64D1D00B3E0F5 /* NSArray+MTLManipulationAdditions.m */; };
+		D9EB04001BD64D1E00B3E0F5 /* NSDictionary+MTLJSONKeyPath.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03B71BD64D1D00B3E0F5 /* NSDictionary+MTLJSONKeyPath.m */; };
+		D9EB04011BD64D1E00B3E0F5 /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03B91BD64D1D00B3E0F5 /* NSDictionary+MTLManipulationAdditions.m */; };
+		D9EB04021BD64D1E00B3E0F5 /* NSDictionary+MTLMappingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03BB1BD64D1D00B3E0F5 /* NSDictionary+MTLMappingAdditions.m */; };
+		D9EB04031BD64D1E00B3E0F5 /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03BD1BD64D1D00B3E0F5 /* NSError+MTLModelException.m */; };
+		D9EB04041BD64D1E00B3E0F5 /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03BF1BD64D1D00B3E0F5 /* NSObject+MTLComparisonAdditions.m */; };
+		D9EB04051BD64D1E00B3E0F5 /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03C11BD64D1D00B3E0F5 /* NSValueTransformer+MTLInversionAdditions.m */; };
+		D9EB04061BD64D1E00B3E0F5 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03C31BD64D1E00B3E0F5 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; };
+		D9EB04071BD64D1E00B3E0F5 /* MJDictionaryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03C61BD64D1E00B3E0F5 /* MJDictionaryCache.m */; };
+		D9EB04081BD64D1E00B3E0F5 /* MJExtensionConst.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03C91BD64D1E00B3E0F5 /* MJExtensionConst.m */; };
+		D9EB04091BD64D1E00B3E0F5 /* MJFoundation.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03CB1BD64D1E00B3E0F5 /* MJFoundation.m */; };
+		D9EB040A1BD64D1E00B3E0F5 /* MJProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03CD1BD64D1E00B3E0F5 /* MJProperty.m */; };
+		D9EB040B1BD64D1E00B3E0F5 /* MJPropertyKey.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03CF1BD64D1E00B3E0F5 /* MJPropertyKey.m */; };
+		D9EB040C1BD64D1E00B3E0F5 /* MJPropertyType.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03D11BD64D1E00B3E0F5 /* MJPropertyType.m */; };
+		D9EB040D1BD64D1E00B3E0F5 /* NSObject+MJClass.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03D31BD64D1E00B3E0F5 /* NSObject+MJClass.m */; };
+		D9EB040E1BD64D1E00B3E0F5 /* NSObject+MJCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03D51BD64D1E00B3E0F5 /* NSObject+MJCoding.m */; };
+		D9EB040F1BD64D1E00B3E0F5 /* NSObject+MJKeyValue.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03D71BD64D1E00B3E0F5 /* NSObject+MJKeyValue.m */; };
+		D9EB04101BD64D1E00B3E0F5 /* NSObject+MJProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03D91BD64D1E00B3E0F5 /* NSObject+MJProperty.m */; };
+		D9EB04111BD64D1E00B3E0F5 /* NSString+MJExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EB03DB1BD64D1E00B3E0F5 /* NSString+MJExtension.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -94,6 +95,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4D2ACEC31EA8416600D3A8AB /* NSString+YYModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+YYModel.h"; sourceTree = "<group>"; };
+		4D2ACEC41EA8416600D3A8AB /* NSString+YYModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+YYModel.m"; sourceTree = "<group>"; };
 		D941E9B11BD54ED800A7B905 /* GithubUserObjectMapper.swift.bak */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = GithubUserObjectMapper.swift.bak; sourceTree = "<group>"; };
 		D9B1937B1BAC714D00F93933 /* ModelBenchmark.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ModelBenchmark.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9B1937F1BAC714D00F93933 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -344,6 +347,8 @@
 				D9EB03261BD64C3200B3E0F5 /* NSObject+YYModel.m */,
 				D9EB03271BD64C3200B3E0F5 /* YYClassInfo.h */,
 				D9EB03281BD64C3200B3E0F5 /* YYClassInfo.m */,
+				4D2ACEC31EA8416600D3A8AB /* NSString+YYModel.h */,
+				4D2ACEC41EA8416600D3A8AB /* NSString+YYModel.m */,
 			);
 			name = YYModel;
 			path = ../../YYModel;
@@ -743,6 +748,7 @@
 				D9EB03F61BD64D1E00B3E0F5 /* JSONValueTransformer.m in Sources */,
 				D9EB03F91BD64D1E00B3E0F5 /* MTLJSONAdapter.m in Sources */,
 				D9B194831BAC737000F93933 /* JSWeiboModel.m in Sources */,
+				4D2ACEC51EA8416600D3A8AB /* NSString+YYModel.m in Sources */,
 				D9EB03F81BD64D1E00B3E0F5 /* EXTScope.m in Sources */,
 				D9EB03FF1BD64D1E00B3E0F5 /* NSArray+MTLManipulationAdditions.m in Sources */,
 				D9EB04051BD64D1E00B3E0F5 /* NSValueTransformer+MTLInversionAdditions.m in Sources */,

--- a/Benchmark/ModelBenchmark/Base.lproj/Main.storyboard
+++ b/Benchmark/ModelBenchmark/Base.lproj/Main.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,17 +18,17 @@
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="See logs in Xcode" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j5c-ge-kV1">
-                                <rect key="frame" x="232" y="290" width="137" height="21"/>
+                                <rect key="frame" x="119" y="323" width="137" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="centerY" secondItem="j5c-ge-kV1" secondAttribute="centerY" id="aDc-DL-Lbw"/>
                             <constraint firstAttribute="centerX" secondItem="j5c-ge-kV1" secondAttribute="centerX" id="nbQ-nb-cHc"/>

--- a/Benchmark/ModelBenchmark/GitHubUser.m
+++ b/Benchmark/ModelBenchmark/GitHubUser.m
@@ -118,7 +118,6 @@ SET_NUM(_following, @"following");
 
 
 
-
 @implementation YYGHUser
 + (NSDictionary *)modelCustomPropertyMapper {
     return @{
@@ -142,6 +141,7 @@ SET_NUM(_following, @"following");
         @"updatedAt" : @"updated_at",
     };
 }
+
 - (void)encodeWithCoder:(NSCoder *)aCoder { [self yy_modelEncodeWithCoder:aCoder]; }
 - (id)initWithCoder:(NSCoder *)aDecoder { return [self yy_modelInitWithCoder:aDecoder]; }
 @end

--- a/Benchmark/ModelBenchmark/ViewController.m
+++ b/Benchmark/ModelBenchmark/ViewController.m
@@ -25,12 +25,35 @@
  FastEasyMapping: https://github.com/Yalantis/FastEasyMapping
  MJExtension: https://github.com/CoderMJLee/MJExtension
  */
+
+@interface YYTag : NSObject
+@property (nonatomic, strong) NSString *tagName; ///< 标签名字，例如"上海·上海文庙"
+@property (nonatomic, strong) NSString *tagScheme; ///< 链接 sinaweibo://...
+@property (nonatomic, assign) int32_t tagType; ///< 1 地点 2其他
+@property (nonatomic, assign) int32_t tagHidden;
+@property (nonatomic, strong) NSURL *urlTypePic; ///< 需要加 _default
+@property (nonatomic, copy)NSString *wbName;
+@end
+@implementation YYTag
++ (NSDictionary *)modelCustomPropertyMapper {
+    return @{@"wbName" : @"wb_name.newName.info[1].nameChangedTime[1].bbb.text[2].text.page[1].test[1]"};
+}
++ (NSString *)replaceKeyFromPropertyName:(NSString *)propertyName {
+    return [propertyName stringWithMapperType:NSStringMapperUnderLineFromCamel];
+}
+@end
+
 @implementation ViewController
 
 - (void)viewDidLoad {
     
     
     [super viewDidLoad];
+    
+    YYTag *tag = [YYTag yy_modelWithJSON:@{@"tag_hidden" : @2 , @"tag_name" : @"上海·上海文庙", @"tag_scheme" : @"http://www.scheme", @"tag_type" : @1, @"url_type_pic" : @"http://www.pic", @"tag_topic" : @"#today is hot", @"wb_name" : @{@"newName" : @{ @"info" : @[@"test-data", @{@"nameChangedTime" : @[@{@"aaa" : @"2013-01"}, @{@"bbb" : @{@"text" : @[@"2014-01", @"2014-02", @{@"text" : @{@"page" : @[@"2017-08", @{@"test" : @[@"2017-09", @"2017-10"]}]}}]}}]}] } }}];
+    
+    NSLog(@"%@", [tag yy_modelToJSONString]);
+    
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         [self benchmarkGithubUser];
         [self benchmarkWeiboStatus];

--- a/YYModel/NSObject+YYModel.h
+++ b/YYModel/NSObject+YYModel.h
@@ -302,6 +302,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable NSDictionary<NSString *, id> *)modelCustomPropertyMapper;
 
+
+#pragma mark - YYAdd
+
+/**
+ A custom method for mapper between property and key
+
+ @discussion if you implement method `+(NSDictionary *)modelCustomPropertyMapper` and return an valid dictionary, then the property in the dicionary will not as method '+ (NSString *)mapperToKeyFromPropertyName:' propertyName parameter
+ 
+ @param propertyName the property's name
+ @return the key associated with the property name
+ */
++ (NSString *)mapperToKeyFromPropertyName:(NSString *)propertyName;
+
 /**
  The generic class mapper for container properties.
  
@@ -426,5 +439,51 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)modelCustomTransformToDictionary:(NSMutableDictionary *)dic;
 
 @end
+
+
+
+@interface NSObject (YYAdd)
+
+
+/**
+ To avoid method `+ (NSDictionary *)yy_modelDictionaryWithClass:json:` too many parameter
+
+ @param json A json array of `NSArray`, `NSString` or `NSData`.
+             Example: [{"name","Mary"},{name:"Joe"}]
+ @return A array, or nil if an error occurs.
+ */
++ (nullable NSDictionary *)yy_modelDictionaryWithJSON:(id)json;
+
+/**
+ To avoid method `(NSDictionary *)yy_modelDictionaryWithClass:json:` too many parameter
+ 
+ @param json A json dictionary of `NSDictionary`, `NSString` or `NSData`.
+             Example: {"user1":{"name","Mary"}, "user2": {name:"Joe"}}
+ @return A dictionary, or nil if an error occurs.
+ */
++ (nullable NSArray *)yy_modelArrayWithKeyValuesArray:(id)json;
+
+
+/**
+ Create model array from a plist file
+
+ @discussion the plist file must be in the main bundle.
+ 
+ @param filename plist file name
+ @return model array
+ */
++ (NSArray *)yy_modelArrayWithFilename:(NSString *)filename;
+
+/**
+ Create model array from a plist file
+ 
+ @param file the full path of the plist file
+ @return model array
+ */
++ (NSArray *)yy_modelArrayWithFile:(NSString *)file;
+
+
+@end
+
 
 NS_ASSUME_NONNULL_END

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -76,42 +76,29 @@ static force_inline BOOL YYEncodingTypeIsCNumber(YYEncodingType type) {
 }
 
 /// Parse a number value from 'id'.
+#pragma mark - _YYAdd
 static force_inline NSNumber *YYNSNumberCreateFromID(__unsafe_unretained id value) {
     static NSCharacterSet *dot;
     static NSDictionary *dic;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         dot = [NSCharacterSet characterSetWithRange:NSMakeRange('.', 1)];
-        dic = @{@"TRUE" :   @(YES),
-                @"True" :   @(YES),
-                @"true" :   @(YES),
-                @"FALSE" :  @(NO),
-                @"False" :  @(NO),
-                @"false" :  @(NO),
-                @"YES" :    @(YES),
-                @"Yes" :    @(YES),
-                @"yes" :    @(YES),
-                @"NO" :     @(NO),
-                @"No" :     @(NO),
-                @"no" :     @(NO),
-                @"NIL" :    (id)kCFNull,
-                @"Nil" :    (id)kCFNull,
-                @"nil" :    (id)kCFNull,
-                @"NULL" :   (id)kCFNull,
-                @"Null" :   (id)kCFNull,
-                @"null" :   (id)kCFNull,
-                @"(NULL)" : (id)kCFNull,
-                @"(Null)" : (id)kCFNull,
-                @"(null)" : (id)kCFNull,
-                @"<NULL>" : (id)kCFNull,
-                @"<Null>" : (id)kCFNull,
-                @"<null>" : (id)kCFNull};
+        dic = @{@"true"  :   @(YES),
+                @"false" :   @(NO),
+                @"yes"   :   @(YES),
+                @"no"    :   @(NO),
+                @"y"     :   @(YES),
+                @"n"     :   @(NO),
+                @"nil"   :   (id)kCFNull,
+                @"null"  :   (id)kCFNull,
+                @"(null)" :  (id)kCFNull,
+                @"<null>" :  (id)kCFNull};
     });
     
     if (!value || value == (id)kCFNull) return nil;
     if ([value isKindOfClass:[NSNumber class]]) return value;
     if ([value isKindOfClass:[NSString class]]) {
-        NSNumber *num = dic[value];
+        NSNumber *num = dic[((NSString *)value).lowercaseString];
         if (num) {
             if (num == (id)kCFNull) return nil;
             return num;
@@ -282,16 +269,25 @@ static force_inline NSDateFormatter *YYISODateFormatter() {
 
 /// Get the value with key paths from dictionary
 /// The dic should be NSDictionary, and the keyPath should not be nil.
+#pragma mark - _YYAdd
 static force_inline id YYValueForKeyPath(__unsafe_unretained NSDictionary *dic, __unsafe_unretained NSArray *keyPaths) {
     id value = nil;
-    for (NSUInteger i = 0, max = keyPaths.count; i < max; i++) {
-        value = dic[keyPaths[i]];
-        if (i + 1 < max) {
-            if ([value isKindOfClass:[NSDictionary class]]) {
-                dic = value;
-            } else {
-                return nil;
-            }
+    for (NSString *keyPath in keyPaths) {
+        NSUInteger left = [keyPath rangeOfString:@"["].location;
+        if (left != NSNotFound) {
+            NSString *sub = [keyPath substringToIndex:left];
+            if (![value isKindOfClass:[NSDictionary class]]) return nil;
+            value = value[sub];
+            if (![value isKindOfClass:[NSArray class]]) return nil;
+            NSUInteger right = [keyPath rangeOfString:@"]"].location;
+            if (right == NSNotFound) return nil;
+            NSString *idxStr = [keyPath substringWithRange:(NSRange){left + 1, right - left - 1}];
+            if (!idxStr.length) return nil;
+            NSInteger idx = idxStr.integerValue;
+            value = (NSArray *)value[idx];
+        } else {
+            if (value && ![value isKindOfClass:[NSDictionary class]]) return nil;
+            value = value ? value[keyPath] : dic[keyPath];
         }
     }
     return value;
@@ -600,6 +596,36 @@ static force_inline id YYValueForMultiKeys(__unsafe_unretained NSDictionary *dic
                 propertyMeta->_next = mapper[mappedToKey] ?: nil;
                 mapper[mappedToKey] = propertyMeta;
             }
+        }];
+    }
+    
+#pragma mark - _YYAdd
+    if ([cls respondsToSelector:@selector(mapperToKeyFromPropertyName:)]) {
+        [allPropertyMetas enumerateKeysAndObjectsUsingBlock:^(NSString *name, _YYModelPropertyMeta *propertyMeta, BOOL *stop) {
+            NSString *mappedToKey = [(id <YYModel>)cls mapperToKeyFromPropertyName:name];
+            if (![mappedToKey isKindOfClass:[NSString class]]) return;
+            if (mappedToKey.length == 0) return;
+            if (!propertyMeta) return;
+            [allPropertyMetas removeObjectForKey:name];
+            propertyMeta->_mappedToKey = mappedToKey;
+            
+            NSArray *keyPath = [mappedToKey componentsSeparatedByString:@"."];
+            for (NSString *onePath in keyPath) {
+                if (onePath.length == 0) {
+                    NSMutableArray *tmp = keyPath.mutableCopy;
+                    [tmp removeObject:@""];
+                    keyPath = tmp;
+                    break;
+                }
+            }
+            
+            if (keyPath.count > 1) {
+                propertyMeta->_mappedToKeyPath = keyPath;
+                [keyPathPropertyMetas addObject:propertyMeta];
+            }
+            
+            propertyMeta->_next = mapper[mappedToKey] ?: nil;
+            mapper[mappedToKey] = propertyMeta;
         }];
     }
     
@@ -1159,6 +1185,7 @@ static void ModelSetWithPropertyMetaArrayFunction(const void *_propertyMeta, voi
  @param model Model, can be nil.
  @return JSON object, nil if an error occurs.
  */
+#pragma mark - _YYAdd
 static id ModelToJSONObjectRecursive(NSObject *model) {
     if (!model || model == (id)kCFNull) return model;
     if ([model isKindOfClass:[NSString class]]) return model;
@@ -1241,30 +1268,67 @@ static id ModelToJSONObjectRecursive(NSObject *model) {
         }
         if (!value) return;
         
+#pragma mark - _YYAdd
         if (propertyMeta->_mappedToKeyPath) {
             NSMutableDictionary *superDic = dic;
             NSMutableDictionary *subDic = nil;
+            NSMutableArray *superArr = nil;
+            NSMutableArray *subArr = nil;
+            BOOL contains = NO;
             for (NSUInteger i = 0, max = propertyMeta->_mappedToKeyPath.count; i < max; i++) {
                 NSString *key = propertyMeta->_mappedToKeyPath[i];
-                if (i + 1 == max) { // end
-                    if (!superDic[key]) superDic[key] = value;
-                    break;
-                }
                 
-                subDic = superDic[key];
-                if (subDic) {
-                    if ([subDic isKindOfClass:[NSDictionary class]]) {
-                        subDic = subDic.mutableCopy;
-                        superDic[key] = subDic;
+                NSRange left = [key rangeOfString:@"["];
+                if (left.location != NSNotFound) {
+                    NSString *sub = [key substringToIndex:left.location];
+                    subDic = superDic[sub];
+                    if (subDic) {
+                        
                     } else {
-                        break;
+                        subDic = [NSMutableDictionary dictionary];
+                        subArr = [NSMutableArray new];
+                        superDic[sub] = subArr;
+                        if (superArr && contains) [superArr addObject:superDic];
                     }
+                    NSInteger start = left.location + left.length;
+                    NSRange right = [key rangeOfString:@"]"];
+                    if (right.location == NSNotFound) {
+                        NSLog(@"the mapper of keypath %@ which class is %@ error", key, propertyMeta->_cls);
+                    } else {
+                        contains = YES;
+                        NSString *countStr = [key substringWithRange:(NSRange){start, right.location - start}];
+                        if (countStr.length == 0) {
+                            NSLog(@"the mapper of keypath %@ which class is %@ error", key, propertyMeta->_cls);
+                        } else {
+                            NSInteger count = countStr.integerValue;
+                            for (NSInteger i = 0; i < count; i++)
+                                [subArr addObject:[NSNull null]];
+                        }
+                    }
+                    
+                    superDic = subDic;
+                    superArr = subArr;
+                    subDic = nil;
+                    subArr = nil;
+                    if (i + 1 == max) if (superArr) [superArr addObject:value];
                 } else {
-                    subDic = [NSMutableDictionary new];
-                    superDic[key] = subDic;
+                    subDic = superDic[key];
+                    if (subDic) {
+                        
+                    } else {
+                        if (i + 1 == max) {
+                            superDic[key] = value;
+                            if (superArr && contains) [superArr addObject:superDic];
+                        } else {
+                            subDic = [NSMutableDictionary new];
+                            superDic[key] = subDic;
+                            if (superArr && contains) [superArr addObject:superDic];
+                        }
+                    }
+                    contains = NO;
+                    superDic = subDic;
+                    subDic = nil;
                 }
-                superDic = subDic;
-                subDic = nil;
             }
         } else {
             if (!dic[propertyMeta->_mappedToKey]) {
@@ -1835,6 +1899,29 @@ static NSString *ModelDescription(NSObject *model) {
         if (obj) result[key] = obj;
     }
     return result;
+}
+
+@end
+
+
+@implementation NSObject (YYAdd)
+
++ (NSArray *)yy_modelArrayWithKeyValuesArray:(id)json {
+    return [NSArray yy_modelArrayWithClass:[self class] json:json];
+}
+
++ (NSDictionary *)yy_modelDictionaryWithJSON:(id)json {
+    return [NSDictionary yy_modelDictionaryWithClass:[self class] json:json];
+}
+
++ (NSArray *)yy_modelArrayWithFilename:(NSString *)filename {
+    if (!filename.length) return nil;
+    return [self yy_modelArrayWithFile:[[NSBundle mainBundle] pathForResource:filename ofType:nil]];
+}
+
++ (NSArray *)yy_modelArrayWithFile:(NSString *)file {
+    if (!file.length) return nil;
+    return [self yy_modelArrayWithKeyValuesArray:[NSArray arrayWithContentsOfFile:file]];
 }
 
 @end

--- a/YYModel/NSString+YYModel.h
+++ b/YYModel/NSString+YYModel.h
@@ -1,0 +1,25 @@
+//
+//  NSString+YYModel.h
+//  ModelBenchmark
+//
+//  Created by HHIOS on 2017/4/20.
+//  Copyright © 2017年 ibireme. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/// 转换类型
+typedef NS_ENUM(NSUInteger, NSStringMapperType) {
+    NSStringMapperDefault = 0,///< 不做转换
+    NSStringMapperFirstCharLower = 1,///< 首字母变小写
+    NSStringMapperFirstCharUpper, ///< 首字母变大写
+    NSStringMapperUnderLineFromCamel, ///< 驼峰转下划线（loveYou -> love_you）
+    NSStringMapperCamelFromUnderLine, ///< 下划线转驼峰（love_you -> loveYou）
+};
+
+
+@interface NSString (YYModel)
+
+- (NSString *)stringWithMapperType:(NSStringMapperType)type;
+
+@end

--- a/YYModel/NSString+YYModel.m
+++ b/YYModel/NSString+YYModel.m
@@ -1,0 +1,92 @@
+//
+//  NSString+YYModel.m
+//  ModelBenchmark
+//
+//  Created by HHIOS on 2017/4/20.
+//  Copyright © 2017年 ibireme. All rights reserved.
+//
+
+#import "NSString+YYModel.h"
+
+
+@interface NSString (__YYAdd)
+/// 驼峰转下划线（loveYou -> love_you）
+- (NSString *)_underlineFromCamel;
+/// 下划线转驼峰（love_you -> loveYou）
+- (NSString *)_camelFromUnderline;
+/// 首字母变大写
+- (NSString *)_firstCharUpper;
+/// 首字母变小写
+- (NSString *)_firstCharLower;
+@end
+@implementation NSString (__YYAdd)
+- (NSString *)_underlineFromCamel {
+    if (self.length == 0) return self;
+    NSMutableString *string = [NSMutableString string];
+    for (NSUInteger i = 0; i<self.length; i++) {
+        unichar c = [self characterAtIndex:i];
+        NSString *cString = [NSString stringWithFormat:@"%c", c];
+        NSString *cStringLower = [cString lowercaseString];
+        if ([cString isEqualToString:cStringLower]) {
+            [string appendString:cStringLower];
+        } else {
+            [string appendString:@"_"];
+            [string appendString:cStringLower];
+        }
+    }
+    return string;
+}
+
+- (NSString *)_camelFromUnderline {
+    if (self.length == 0) return self;
+    NSMutableString *string = [NSMutableString string];
+    NSArray *cmps = [self componentsSeparatedByString:@"_"];
+    for (NSUInteger i = 0; i<cmps.count; i++) {
+        NSString *cmp = cmps[i];
+        if (i && cmp.length) {
+            [string appendString:[NSString stringWithFormat:@"%c", [cmp characterAtIndex:0]].uppercaseString];
+            if (cmp.length >= 2) [string appendString:[cmp substringFromIndex:1]];
+        } else {
+            [string appendString:cmp];
+        }
+    }
+    return string;
+}
+
+- (NSString *)_firstCharLower {
+    if (self.length == 0) return self;
+    NSMutableString *string = [NSMutableString string];
+    [string appendString:[NSString stringWithFormat:@"%c", [self characterAtIndex:0]].lowercaseString];
+    if (self.length >= 2) [string appendString:[self substringFromIndex:1]];
+    return string;
+}
+
+- (NSString *)_firstCharUpper {
+    if (self.length == 0) return self;
+    NSMutableString *string = [NSMutableString string];
+    [string appendString:[NSString stringWithFormat:@"%c", [self characterAtIndex:0]].uppercaseString];
+    if (self.length >= 2) [string appendString:[self substringFromIndex:1]];
+    return string;
+}
+@end
+
+
+@implementation NSString (YYModel)
+
+- (NSString *)stringWithMapperType:(NSStringMapperType)type {
+    switch (type) {
+        case NSStringMapperFirstCharLower:
+            return self._firstCharLower;
+        case NSStringMapperFirstCharUpper:
+            return self._firstCharUpper;
+        case NSStringMapperUnderLineFromCamel:
+            return self._underlineFromCamel;
+        case NSStringMapperCamelFromUnderLine:
+            return self._camelFromUnderline;
+        default:
+            break;
+    }
+    return self;
+}
+
+@end

--- a/YYModel/YYModel.h
+++ b/YYModel/YYModel.h
@@ -16,7 +16,34 @@ FOUNDATION_EXPORT double YYModelVersionNumber;
 FOUNDATION_EXPORT const unsigned char YYModelVersionString[];
 #import <YYModel/NSObject+YYModel.h>
 #import <YYModel/YYClassInfo.h>
+#import <YYModel/NSString+YYModel.h>
 #else
 #import "NSObject+YYModel.h"
 #import "YYClassInfo.h"
+#import "NSString+YYModel.h"
 #endif
+
+
+
+#define YYCodingImplementation \
+- (id)initWithCoder:(NSCoder *)decoder \
+{ \
+self = [super init]; \
+return [self modelInitWithCoder:decoder]; \
+} \
+\
+- (void)encodeWithCoder:(NSCoder *)encoder \
+{ \
+[self modelEncodeWithCoder:encoder]; \
+}
+
+
+#define YYCopyImplementation \
+- (id)copyWithZone:(NSZone *)zone { return [self modelCopy]; }
+
+#define YYHashImplementation \
+- (NSUInteger)hash { return [self modelHash]; }
+
+#define YYEqualImplementation \
+- (BOOL)isEqual:(id)object { return [self modelIsEqual:object]; }
+


### PR DESCRIPTION
1. 在YYModel协议中添加放方法`+ (NSString *)mapperToKeyFromPropertyName:`,
用于属性名和字典key的统一转换
2. 支持属性映射到json数组指定下标元素
3. 添加NSString分类文件
4. 可查看ViewController.m事例效果, 如果觉得有必要添加这些方法, 麻烦作者斟酌这些方法的实现是否最优, 也可查看这些方法的注释, 不过笔者的英语不是太好, 囧!
5. 非常感谢作者给我们提供这么优秀的框架