### PR TITLE
modelContainerPropertyGenericClass 方法返回的 _genericCls 应该优先于属性本身的类型

### DIFF
--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -1007,9 +1007,10 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
         BOOL isNull = (value == (id)kCFNull);
         switch (meta->_type & YYEncodingTypeMask) {
             case YYEncodingTypeObject: {
+                Class cls = meta->_genericCls ?: meta->_cls;
                 if (isNull) {
                     ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, (id)nil);
-                } else if ([value isKindOfClass:meta->_cls] || !meta->_cls) {
+                } else if ([value isKindOfClass:cls] || !cls) {
                     ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, (id)value);
                 } else if ([value isKindOfClass:[NSDictionary class]]) {
                     NSObject *one = nil;
@@ -1019,10 +1020,8 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                     if (one) {
                         [one yy_modelSetWithDictionary:value];
                     } else {
-                        Class cls = meta->_cls;
                         if (meta->_hasCustomClassFromDictionary) {
-                            cls = [cls modelCustomClassForDictionary:value];
-                            if (!cls) cls = meta->_genericCls; // for xcode code coverage
+                            cls = [cls modelCustomClassForDictionary:value] ?: cls;
                         }
                         one = [cls new];
                         [one yy_modelSetWithDictionary:value];


### PR DESCRIPTION
这样定义属性（不希望暴露该属性的具体实现的类）：
```objc
@property (nonatomic) NSObject<YYProtocol> *anObject;
```
然后通过 `modelContainerPropertyGenericClass` 方法指定该属性的 `genericClass`：
```objc
+ (nullable NSDictionary<NSString *, id> *)modelContainerPropertyGenericClass {
    return @{@"anObject": [YYClass class]};
}
```

问题：预期 `anObject` 的值是  `YYClass` 的实例，但是结果却是 `NSDictionary`，因为 `anObject` 对应的 JSON 是 `NSDictionary`，而 `NSDictionary` 是属性类型 `NSObject` 的子类，因而被直接赋值给 `anObject`（把 `NSObject<YYProtocol> *` 改成 `id<YYProtocol>` 结果相同）；

解决：`modelContainerPropertyGenericClass` 方法返回 `_genericCls ` 该优先于属性本身的类型 `_cls `。

另外：这段代码里，如果通过 `getter` 获取到 `one` 就直接调用 `yy_modelSetWithDictionary:` 更新其属性，是不是应该判断下 `one` 的 `Class` 是否与 `modelCustomClassForDictionary:` 返回的 `Class` 相同？因为 `modelCustomClassForDictionary:` 可能根据 `value` 返回不同的 `Class` —— 这个问题我没改，因为我不确定 `if (one) [one yy_modelSetWithDictionary:value]` 的目的。
```objc
NSObject *one = nil;
if (meta->_getter) {
    one = ((id (*)(id, SEL))(void *) objc_msgSend)((id)model, meta->_getter);
}
if (one) {
    [one yy_modelSetWithDictionary:value];
} else {
    if (meta->_hasCustomClassFromDictionary) {
        cls = [cls modelCustomClassForDictionary:value] ?: cls;
    }
    one = [cls new];
    [one yy_modelSetWithDictionary:value];
    ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)model, meta->_setter, (id)one);
}
```
