### PR TITLE
增加字典数组转模型数组的方法

### DIFF
--- a/YYModel/NSObject+YYModel.h
+++ b/YYModel/NSObject+YYModel.h
@@ -104,7 +104,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 /**
- Creates and returns a new instance of the receiver from an array containing key-value dictionary, automatic parsing multiple array.
+ Creates and returns a new instance of the receiver from an array containing key-value dictionary, automatic parsing multiple array, if contain anything else element except dictionary, mothed will return a uninitialized instance.
 
  @param keyValueArray An array containing key-value dictionary mapped to the instance's properties.
  @return A new array containing instance.

--- a/YYModel/NSObject+YYModel.h
+++ b/YYModel/NSObject+YYModel.h
@@ -102,6 +102,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable instancetype)yy_modelWithDictionary:(NSDictionary *)dictionary;
 
+
+/**
+ Creates and returns a new instance of the receiver from an array containing key-value dictionary, automatic parsing multiple array.
+
+ @param keyValueArray An array containing key-value dictionary mapped to the instance's properties.
+ @return A new array containing instance.
+ */
++ (NSMutableArray *)yy_modelArrayWithKeyValueArray:(NSArray *)keyValueArray;
+
 /**
  Set the receiver's properties with a json object.
  

--- a/YYModel/NSObject+YYModel.h
+++ b/YYModel/NSObject+YYModel.h
@@ -104,7 +104,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 /**
- Creates and returns a new instance of the receiver from an array containing key-value dictionary, automatic parsing multiple array, if contain anything else element except dictionary, mothed will return a uninitialized instance.
+ Creates and returns a new instance of the receiver from an array containing key-value dictionary, automatic parsing multiple array, if contain anything else element except dictionary, method will return a uninitialized instance.
 
  @param keyValueArray An array containing key-value dictionary mapped to the instance's properties.
  @return A new array containing instance.

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -1454,6 +1454,25 @@ static NSString *ModelDescription(NSObject *model) {
     return [self yy_modelWithDictionary:dic];
 }
 
++ (NSMutableArray *)yy_modelArrayWithKeyValueArray:(NSArray *)keyValueArray {
+    if (!keyValueArray || keyValueArray == (id)kCFNull) return nil;
+    if (![keyValueArray isKindOfClass:[NSArray class]]) return nil;
+    NSMutableArray *modelArray = [NSMutableArray array];
+    return [self _yy_modelArrayWithRecurArray:keyValueArray modelArray:modelArray];;
+}
+
++ (NSMutableArray *)_yy_modelArrayWithRecurArray:(NSArray *)array modelArray:(NSMutableArray *)modelArray {
+    [array enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        if ([obj isKindOfClass:[NSArray class]]) {
+            NSMutableArray *array = [NSMutableArray array];
+            [modelArray addObject:[self _yy_modelArrayWithRecurArray:obj modelArray:array]];
+        } else {
+            [modelArray addObject:[self yy_modelWithDictionary:obj]];
+        }
+    }];
+    return modelArray;
+}
+
 + (instancetype)yy_modelWithDictionary:(NSDictionary *)dictionary {
     if (!dictionary || dictionary == (id)kCFNull) return nil;
     if (![dictionary isKindOfClass:[NSDictionary class]]) return nil;

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -1467,6 +1467,9 @@ static NSString *ModelDescription(NSObject *model) {
             NSMutableArray *array = [NSMutableArray array];
             [modelArray addObject:[self _yy_modelArrayWithRecurArray:obj modelArray:array]];
         } else {
+            if (![obj isKindOfClass:[NSDictionary class]]) {
+                obj = [NSDictionary dictionary];
+            }
             [modelArray addObject:[self yy_modelWithDictionary:obj]];
         }
     }];


### PR DESCRIPTION
提供包含字典数组的转换方法：
+ (NSMutableArray *)yy_modelArrayWithKeyValueArray:(NSArray *)keyValueArray;
递归调用+ (instancetype)yy_modelWithDictionary:(NSDictionary *)dictionary方法不改变原有嵌套结构，如果元素不是字典则返回一个没有默认值的模型实例。