### PR TITLE
Fix parse issue when genericClass of array is `NSURL`

### DIFF
--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -902,6 +902,29 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                             for (id one in valueArr) {
                                 if ([one isKindOfClass:meta->_genericCls]) {
                                     [objectArr addObject:one];
+                                } else if (meta->_genericCls == [NSString class]) {
+                                    if ([one isKindOfClass:[NSNumber class]]) {
+                                        [objectArr addObject:((NSNumber *)one).stringValue];
+                                    }
+                                } else if (meta->_genericCls == [NSMutableString class]) {
+                                    if ([one isKindOfClass:[NSString class]]) {
+                                        [objectArr addObject:((NSString *)one).mutableCopy];
+                                    } else if ([one isKindOfClass:[NSNumber class]]) {
+                                        [objectArr addObject:((NSNumber *)one).stringValue.mutableCopy];
+                                    }
+                                } else if (meta->_genericCls == [NSNumber class]) {
+                                    [objectArr addObject:YYNSNumberCreateFromID(one)];
+                                } else if (meta->_genericCls == [NSURL class]) {
+                                    if ([one isKindOfClass:[NSURL class]]) {
+                                        [objectArr addObject:[NSURL URLWithString:one]];
+                                    } else if ([one isKindOfClass:[NSString class]]) {
+                                        NSCharacterSet *set = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+                                        NSString *str = [one stringByTrimmingCharactersInSet:set];
+                                        if (str.length == 0) {
+                                        } else {
+                                            [objectArr addObject:[[NSURL alloc] initWithString:str]];
+                                        }
+                                    }
                                 } else if ([one isKindOfClass:[NSDictionary class]]) {
                                     Class cls = meta->_genericCls;
                                     if (meta->_hasCustomClassFromDictionary) {

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -915,9 +915,7 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                                 } else if (meta->_genericCls == [NSNumber class]) {
                                     [objectArr addObject:YYNSNumberCreateFromID(one)];
                                 } else if (meta->_genericCls == [NSURL class]) {
-                                    if ([one isKindOfClass:[NSURL class]]) {
-                                        [objectArr addObject:[NSURL URLWithString:one]];
-                                    } else if ([one isKindOfClass:[NSString class]]) {
+                                    if ([one isKindOfClass:[NSString class]]) {
                                         NSCharacterSet *set = [NSCharacterSet whitespaceAndNewlineCharacterSet];
                                         NSString *str = [one stringByTrimmingCharactersInSet:set];
                                         if (str.length == 0) {

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -902,25 +902,17 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                             for (id one in valueArr) {
                                 if ([one isKindOfClass:meta->_genericCls]) {
                                     [objectArr addObject:one];
-                                } else if (meta->_genericCls == [NSString class]) {
-                                    if ([one isKindOfClass:[NSNumber class]]) {
-                                        [objectArr addObject:((NSNumber *)one).stringValue];
-                                    }
-                                } else if (meta->_genericCls == [NSMutableString class]) {
-                                    if ([one isKindOfClass:[NSString class]]) {
-                                        [objectArr addObject:((NSString *)one).mutableCopy];
-                                    } else if ([one isKindOfClass:[NSNumber class]]) {
-                                        [objectArr addObject:((NSNumber *)one).stringValue.mutableCopy];
-                                    }
+                                } else if (meta->_genericCls == [NSString class] && [one isKindOfClass:[NSNumber class]]) {
+                                    [objectArr addObject:((NSNumber *)one).stringValue];
+                                } else if (meta->_genericCls == [NSMutableString class] && [one isKindOfClass:[NSNumber class]]) {
+                                    [objectArr addObject:((NSNumber *)one).stringValue.mutableCopy];
                                 } else if (meta->_genericCls == [NSNumber class]) {
                                     [objectArr addObject:YYNSNumberCreateFromID(one)];
-                                } else if (meta->_genericCls == [NSURL class]) {
-                                    if ([one isKindOfClass:[NSString class]]) {
-                                        NSCharacterSet *set = [NSCharacterSet whitespaceAndNewlineCharacterSet];
-                                        NSString *str = [one stringByTrimmingCharactersInSet:set];
-                                        if (str.length > 0) {
-                                            [objectArr addObject:[[NSURL alloc] initWithString:str]];
-                                        }
+                                } else if (meta->_genericCls == [NSURL class] && [one isKindOfClass:[NSString class]]) {
+                                    NSCharacterSet *set = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+                                    NSString *str = [one stringByTrimmingCharactersInSet:set];
+                                    if (str.length > 0) {
+                                        [objectArr addObject:[[NSURL alloc] initWithString:str]];
                                     }
                                 } else if ([one isKindOfClass:[NSDictionary class]]) {
                                     Class cls = meta->_genericCls;

--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -918,8 +918,7 @@ static void ModelSetValueForProperty(__unsafe_unretained id model,
                                     if ([one isKindOfClass:[NSString class]]) {
                                         NSCharacterSet *set = [NSCharacterSet whitespaceAndNewlineCharacterSet];
                                         NSString *str = [one stringByTrimmingCharactersInSet:set];
-                                        if (str.length == 0) {
-                                        } else {
+                                        if (str.length > 0) {
                                             [objectArr addObject:[[NSURL alloc] initWithString:str]];
                                         }
                                     }

--- a/YYModelTests/YYTestCustomClass.m
+++ b/YYModelTests/YYTestCustomClass.m
@@ -47,6 +47,11 @@
 @property (nonatomic, strong) NSDictionary *userDict;
 @property (nonatomic, strong) NSSet *userSet;
 @property (nonatomic, strong) YYBaseUser *user;
+@property (nonatomic, strong) NSArray<NSURL *> *imageURLs;
+@property (nonatomic, strong) NSArray<NSString *> *phones;
+@property (nonatomic, strong) NSArray<NSMutableString *> *editPhones;
+@property (nonatomic, strong) NSArray<NSNumber *> *scores;
+
 @end
 
 @implementation YYTestCustomClassModel
@@ -54,7 +59,12 @@
 + (NSDictionary *)modelContainerPropertyGenericClass {
     return @{@"users" : YYBaseUser.class,
              @"userDict" : YYBaseUser.class,
-             @"userSet" : YYBaseUser.class};
+             @"userSet" : YYBaseUser.class,
+             @"imageURLs" : NSURL.class,
+             @"phones" : NSString.class,
+             @"editPhones" : NSMutableString.class,
+             @"scores" : NSNumber.class,
+             };
 }
 + (Class)modelCustomClassForDictionary:(NSDictionary*)dictionary {
     if (dictionary[@"localName"]) {
@@ -80,6 +90,9 @@
     NSDictionary *jsonUserBase = @{@"uid" : @123, @"name" : @"Harry"};
     NSDictionary *jsonUserLocal = @{@"uid" : @123, @"name" : @"Harry", @"localName" : @"HarryLocal"};
     NSDictionary *jsonUserRemote = @{@"uid" : @123, @"name" : @"Harry", @"remoteName" : @"HarryRemote"};
+    NSArray *jsonImageURLs = @[@"http://aaa.com", @"http://bbb.com"];
+    NSArray *jsonPhones = @[@13000000001, @13000000002, @13000000003];
+    NSArray *jsonScores = @[@"90", @"80", @"70"];
     
     user = [YYBaseUser yy_modelWithDictionary:jsonUserBase];
     XCTAssert([user isMemberOfClass:[YYBaseUser class]]);
@@ -90,6 +103,18 @@
     user = [YYBaseUser yy_modelWithDictionary:jsonUserRemote];
     XCTAssert([user isMemberOfClass:[YYRemoteUser class]]);
     
+    model = [YYTestCustomClassModel yy_modelWithJSON:@{@"imageURLs" : jsonImageURLs}];
+    XCTAssert([model.imageURLs[0] isMemberOfClass:[NSURL class]]);
+    
+    model = [YYTestCustomClassModel yy_modelWithJSON:@{@"phones" : jsonPhones}];
+    XCTAssert([model.phones[0] isKindOfClass:[NSString class]]);
+
+    model = [YYTestCustomClassModel yy_modelWithJSON:@{@"editPhones" : jsonPhones}];
+    XCTAssert([model.editPhones[0] isKindOfClass:[NSMutableString class]]);
+
+    model = [YYTestCustomClassModel yy_modelWithJSON:@{@"scores" : jsonScores}];
+    XCTAssert([model.scores[0] isKindOfClass:[NSNumber class]]);
+
     
     model = [YYTestCustomClassModel yy_modelWithJSON:@{@"user" : jsonUserLocal}];
     XCTAssert([model.user isMemberOfClass:[YYLocalUser class]]);

--- a/YYModelTests/YYTestCustomClass.m
+++ b/YYModelTests/YYTestCustomClass.m
@@ -90,8 +90,8 @@
     NSDictionary *jsonUserBase = @{@"uid" : @123, @"name" : @"Harry"};
     NSDictionary *jsonUserLocal = @{@"uid" : @123, @"name" : @"Harry", @"localName" : @"HarryLocal"};
     NSDictionary *jsonUserRemote = @{@"uid" : @123, @"name" : @"Harry", @"remoteName" : @"HarryRemote"};
-    NSArray *jsonImageURLs = @[@"http://aaa.com", @"http://bbb.com"];
-    NSArray *jsonPhones = @[@13000000001, @13000000002, @13000000003];
+    NSArray *jsonImageURLs = @[@"http://aaa.com", @"http://bbb.com", @""];
+    NSArray *jsonPhones = @[@13000000001, @13000000002, @"13000000003"];
     NSArray *jsonScores = @[@"90", @"80", @"70"];
     
     user = [YYBaseUser yy_modelWithDictionary:jsonUserBase];

--- a/YYModelTests/YYTestCustomClass.m
+++ b/YYModelTests/YYTestCustomClass.m
@@ -110,7 +110,9 @@
     XCTAssert([model.phones[0] isKindOfClass:[NSString class]]);
 
     model = [YYTestCustomClassModel yy_modelWithJSON:@{@"editPhones" : jsonPhones}];
-    XCTAssert([model.editPhones[0] isKindOfClass:[NSMutableString class]]);
+    //__NSCFConstantString->__NSCFString->NSMutableString->NSString
+    //model.editPhones[2]不是 NSMutableString，使用 `appendString:` 会导致 crash
+    XCTAssert([model.editPhones[2] isKindOfClass:[NSMutableString class]]);
 
     model = [YYTestCustomClassModel yy_modelWithJSON:@{@"scores" : jsonScores}];
     XCTAssert([model.scores[0] isKindOfClass:[NSNumber class]]);


### PR DESCRIPTION
fixed #190 
问题根本原因在于，数组解析时，json 数据格式与目标模型格式不匹配