### PR TITLE
switch to use method `decodeObjectOfClass:forKey:` to decode an object

### DIFF
--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -1701,7 +1701,7 @@ static NSString *ModelDescription(NSObject *model) {
             YYEncodingType type = propertyMeta->_type & YYEncodingTypeMask;
             switch (type) {
                 case YYEncodingTypeObject: {
-                    id value = [aDecoder decodeObjectForKey:propertyMeta->_name];
+                    id value = [aDecoder decodeObjectOfClass:propertyMeta->_cls forKey:propertyMeta->_name];
                     ((void (*)(id, SEL, id))(void *) objc_msgSend)((id)self, propertyMeta->_setter, value);
                 } break;
                 case YYEncodingTypeSEL: {


### PR DESCRIPTION
Hello bireme,

Here is the reason why this pull request happened.

I have a model like this:

```
@interface HWPerson : NSObject <NSSecureCoding>

@property (nonatomic, copy) NSString *firstName;
@property (nonatomic, copy) NSString *lastName;
@property (nonatomic, assign) NSInteger age;
@property (nonatomic, strong) NSURL *avatarURL;

@end

@implementation HWPerson

+ (BOOL)supportsSecureCoding {
    return YES;
}

- (void)encodeWithCoder:(NSCoder *)aCoder {
    [self yy_modelEncodeWithCoder:aCoder];
}

- (instancetype)initWithCoder:(NSCoder *)aDecoder {
    return [self yy_modelInitWithCoder:aDecoder];
}

@end
```

I'd like to use `NSSecureCoding ` rather than `NSCoding`. Then something unexpected happened. I can `NSKeyedArchiver` to save this model to disk successfully, but I cannot read and unarchive it from the disk. There's an error. 

After debug, I found it is because the `NSURL` property. This property cannot be unarchived in `yy_modelInitWithCoder:` with method `decodeObjectforKey:`. We have to use `decodeObjectOfClass:forKey:`.

Here is the example code to save and read this mode:

```
- (void)save {
    HWPerson *person = [[HWPerson alloc] init];
    person.firstName = @"will";
    person.lastName = @"chen";
    person.age = 28;
    person.avatarURL = [NSURL URLWithString:@"https://example.com/avatar.png"];

    if (@available(iOS 11, *)) {
        NSError *error = nil;
        NSData *personData = [NSKeyedArchiver archivedDataWithRootObject:person
                                                   requiringSecureCoding:YES
                                                                   error:&error];
        if (!personData) {
            NSLog(@"Archiver Failed: %@", error.localizedDescription);
        }

        error = nil;
        BOOL result = [personData writeToFile:[self filePath]
                                      options:0
                                        error:&error];
        if (!result) {
            NSLog(@"Write to File Failed: %@", error.localizedDescription);
        }
    } else {
        BOOL result = [NSKeyedArchiver archiveRootObject:person toFile:[self filePath]];
        if (!result) {
            NSLog(@"Write to File Failed");
        }
    }
}

- (void)read {
    if (@available(iOS 11, *)) {
        NSError *error = nil;
        NSData *data = [NSData dataWithContentsOfFile:[self filePath]];
        HWPerson *person = [NSKeyedUnarchiver unarchivedObjectOfClass:HWPerson.class
                                                             fromData:data
                                                                error:&error];
        if (!person) {
            NSLog(@"Read from File Failed: %@", error.localizedDescription);
        } else {
            NSLog(@"%@·%@ is %ld", person.firstName, person.lastName, person.age);
            NSLog(@"Avatar URL: %@", person.avatarURL);
        }
    } else {
        HWPerson *person = [NSKeyedUnarchiver unarchiveObjectWithFile:[self filePath]];
        if (!person) {
            NSLog(@"Read from File Failed");
        } else {
            NSLog(@"%@·%@ is %ld", person.firstName, person.lastName, person.age);
            NSLog(@"Avatar URL: %@", person.avatarURL);
        }
    }
}
```