### PR TITLE
fix string type failure

### DIFF
--- a/YYModel/NSObject+YYModel.m
+++ b/YYModel/NSObject+YYModel.m
@@ -1160,7 +1160,8 @@ static void ModelSetWithPropertyMetaArrayFunction(const void *_propertyMeta, voi
  */
 static id ModelToJSONObjectRecursive(NSObject *model) {
     if (!model || model == (id)kCFNull) return model;
-    if ([model isKindOfClass:[NSString class]]) return model;
+    if ([model isKindOfClass:[NSString class]])
+        return [((NSString *)model) dataUsingEncoding:NSUTF8StringEncoding];
     if ([model isKindOfClass:[NSNumber class]]) return model;
     if ([model isKindOfClass:[NSDictionary class]]) {
         if ([NSJSONSerialization isValidJSONObject:model]) return model;


### PR DESCRIPTION
convert string type failure like that
`"{\"type\":3,\"cfg\":[{\"pos\":2,\"ct\":1},{\"pos\":3,\"ct\":3},{\"pos\":4,\"ct\":6},{\"pos\":5,\"ct\":10}]}"`